### PR TITLE
[bug] Expand CodeQL JS/TS paths to infra/cdk

### DIFF
--- a/.github/codeql/codeql-javascript-typescript.yml
+++ b/.github/codeql/codeql-javascript-typescript.yml
@@ -7,6 +7,10 @@ paths:
   - "*.mjs"
   - "*.ts"
   - "*.tsx"
+  - "infra/cdk/**/*.js"
+  - "infra/cdk/**/*.mjs"
+  - "infra/cdk/**/*.ts"
+  - "infra/cdk/**/*.tsx"
 
 # EN: Skip generated, test-only, and documentation paths to keep alerts actionable.
 # CN: 跳过生成物、纯测试和文档路径，让告警更聚焦可行动代码。


### PR DESCRIPTION
Closes #1

## 变更摘要
- 问题是：CodeQL JavaScript/TypeScript 配置只覆盖了根目录的 `*.ts` / `*.tsx`，而仓库真实的 TypeScript 源码在 `infra/cdk/**/*.ts`。
- 为什么要改：这会让 `codeql.yml` 在官方 runner 上出现 `No JavaScript or TypeScript code found`，并在 finalize 阶段失败。
- 这次改了什么：把 `.github/codeql/codeql-javascript-typescript.yml` 的 `paths` 扩展到 `infra/cdk/**/*.js`、`infra/cdk/**/*.mjs`、`infra/cdk/**/*.ts`、`infra/cdk/**/*.tsx`。
- 没有改什么：没有修改分析逻辑、workflow 触发器或仓库源码。
- 对外可见的结果：CodeQL 现在会扫描 `infra/cdk` 下的真实 JS/TS 源码，避免空分析范围导致的失败。

## 关联 Issue
- 已完全覆盖：#1

## 变更类型
- [ ] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [x] CI / workflow
- [x] 配置
- [ ] 测试
- [ ] 维护 / 清理

## 影响范围
- 受影响的目录：`.github/codeql/`
- 受影响的模块 / 服务：GitHub Code Scanning 的 CodeQL JS/TS job
- 受影响的 workflow：`CodeQL JavaScript / TypeScript`
- 受影响的数据结构 / 配置：CodeQL JS/TS 路径过滤规则
- 是否影响默认 PR 门禁：是，修复后该 workflow 不再因空扫描范围失败。
- 是否影响部署 / 回滚：否。

## 详细说明
### 1. 主要改动
- 将 CodeQL JS/TS 的 `paths` 从根目录通配扩展为实际源码目录 `infra/cdk/**/*.ts` 等。

### 2. 设计选择
- 为什么采用当前方案：最小修改即可让 CodeQL 识别真实源码。
- 备选方案是什么：移除 `paths` 约束，或改为更大的仓库级扫描范围。
- 为什么没有选择备选方案：当前仓库只需要覆盖真实 JS/TS 源码目录，扩大到全仓库会增加噪音。

### 3. 兼容性
- 是否向后兼容：是。
- 是否需要迁移：否。
- 是否需要重建索引 / 重新部署 / 重新生成产物：否。
- 是否引入新环境变量 / 新配置项：否。

### 4. 文件清单
- 修改文件：`.github/codeql/codeql-javascript-typescript.yml`
- 新增文件：无
- 删除文件：无
- 重命名文件：无

## 验证
### 本地验证
- `uv sync --locked --project services`
- `uv run --project services python tools/ci/validate_workflows.py`
- `uv run --project services pytest -q`

### 自动化验证
- [x] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [x] workflow / CI 检查
- [ ] 其他：

### 验证结果
- 通过项：`tools/ci/validate_workflows.py`、`pytest -q`（305 passed, 2 skipped）
- 失败项：无
- 未执行项及原因：无

## 风险与回滚
- 主要风险：CodeQL 现在会扫描到更多真实源码，历史告警可能增加。
- 风险缓解方式：只扩展到 `infra/cdk` 下的实际 TS/JS 源码目录。
- 回滚方式：恢复 `.github/codeql/codeql-javascript-typescript.yml` 原始 `paths` 即可。
- 回滚后遗留影响：CodeQL 会恢复空扫描范围问题。
- 是否需要灰度：否。

## 对业务 / 运维的影响
- 是否影响线上行为：否。
- 是否影响部署流程：否。
- 是否影响监控 / 告警：仅影响 CodeQL 扫描结果。
- 是否影响成本 / 性能：否。
- 是否影响运维手册：否。

## 待确认事项
- 无。