### PR TITLE
Allow embedding model overrides in deploys

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -36,7 +36,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AWS_REGION: ${{ inputs.region || secrets.AWS_REGION }}
+      AWS_REGION: ${{ inputs.region || secrets.AWS_REGION || 'us-east-1' }}
+      AWS_DEFAULT_REGION: ${{ inputs.region || secrets.AWS_REGION || 'us-east-1' }}
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -31,10 +31,15 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      OPENAI_API_BASE_URL: ${{ secrets.OPENAI_API_BASE_URL }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_EMBEDDING_MODEL: ${{ secrets.OPENAI_EMBEDDING_MODEL }}
+      PADDLE_OCR_API_TOKEN: ${{ secrets.PADDLE_OCR_API_TOKEN }}
       MCP_CDK_ASSET_DIR: ./release-assets
 
     steps:

--- a/infra/cdk/lib/config.ts
+++ b/infra/cdk/lib/config.ts
@@ -96,6 +96,7 @@ export interface DeploymentInputs {
   geminiApiKey?: string;
   openaiApiKey?: string;
   openaiApiBaseUrl?: string;
+  openaiEmbeddingModel?: string;
   paddleAllowedHosts?: string;
   remoteMcpDefaultTenantId?: string;
   cloudfrontDistributionDomain?: string;
@@ -120,6 +121,7 @@ export function resolveDeploymentInputs(env: NodeJS.ProcessEnv): DeploymentInput
     openaiApiBaseUrl:
       optionalEnv(env, 'OPENAI_API_BASE_URL') ??
       optionalEnv(env, 'OPENAI_BASE_URL'),
+    openaiEmbeddingModel: optionalEnv(env, 'OPENAI_EMBEDDING_MODEL'),
     paddleAllowedHosts: optionalEnv(env, 'PADDLE_OCR_ALLOWED_HOSTS'),
     remoteMcpDefaultTenantId: optionalEnv(env, 'REMOTE_MCP_DEFAULT_TENANT_ID'),
     cloudfrontDistributionDomain: optionalEnv(env, 'CLOUDFRONT_DISTRIBUTION_DOMAIN'),

--- a/infra/cdk/lib/pipeline/compute.ts
+++ b/infra/cdk/lib/pipeline/compute.ts
@@ -244,7 +244,7 @@ function buildLambdaEnvironment(params: {
     PADDLE_OCR_HTTP_TIMEOUT_SECONDS: String(defaultSettings.paddle_http_timeout_seconds),
     PADDLE_OCR_STATUS_TIMEOUT_SECONDS: String(defaultSettings.paddle_status_timeout_seconds),
     PADDLE_OCR_ALLOWED_HOSTS: deploymentInputs.paddleAllowedHosts ?? '',
-    OPENAI_EMBEDDING_MODEL: pipelineConfig.defaults.openai_embedding_model,
+    OPENAI_EMBEDDING_MODEL: deploymentInputs.openaiEmbeddingModel ?? defaultSettings.openai_embedding_model,
     CLOUDFRONT_URL_TTL_SECONDS: String(defaultSettings.cloudfront_url_ttl_seconds),
     ALLOW_UNAUTHENTICATED_QUERY: String(defaultSettings.allow_unauthenticated_query),
   };


### PR DESCRIPTION
## Summary
- Allow `OPENAI_EMBEDDING_MODEL` to override the CDK default when provided, while keeping `pipeline-config.json` as the fallback.
- Default GitHub Actions AWS region handling to `us-east-1` when no region secret/input is provided.
- Pass canonical OpenAI and Paddle secrets through the production deploy workflow so deployment-time environment values can override defaults.

## Notes
- The CDK change is in `infra/cdk/lib/config.ts` and `infra/cdk/lib/pipeline/compute.ts`.
- The workflow change keeps the deploy path consistent with manual dispatch secrets and default region handling.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads an `OPENAI_EMBEDDING_MODEL` environment-variable override through the CDK config/compute layer and surfaces it in the production deploy workflow, while also aligning AWS region handling by adding the `AWS_DEFAULT_REGION` env var (with `us-east-1` fallback) to both the deploy and destroy workflows.

**Changes at a glance:**
- `infra/cdk/lib/config.ts` — adds `openaiEmbeddingModel?: string` to `DeploymentInputs` and resolves it from `OPENAI_EMBEDDING_MODEL` via `optionalEnv` (consistent with existing patterns).
- `infra/cdk/lib/pipeline/compute.ts` — applies `deploymentInputs.openaiEmbeddingModel ?? defaultSettings.openai_embedding_model` instead of the hard-coded config value, preserving backwards compatibility when the env var is absent.
- `.github/workflows/prod-deploy.yml` — adds `AWS_DEFAULT_REGION` with a `us-east-1` fallback and injects `OPENAI_API_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_EMBEDDING_MODEL`, and `PADDLE_OCR_API_TOKEN` as job-level env vars so they flow into the CDK deploy step.
- `.github/workflows/destroy.yml` — adds `AWS_DEFAULT_REGION` with the same fallback logic as `AWS_REGION`.

The implementation is minimal, well-scoped, and consistent with how other deployment-time overrides (e.g. `paddleAllowedHosts`, `openaiApiBaseUrl`) are handled throughout the codebase. No Gemini-related variables are added, but that matches the pre-existing pattern — `GEMINI_API_KEY` was already absent from the workflow before this PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are backwards-compatible, correctly scoped, and follow established patterns.

All four changed files introduce additive, non-breaking behaviour. The CDK change uses a `??` fallback to the existing config value, so deployments without the new env var are unaffected. The workflow changes add env vars that were previously missing and correctly default to `us-east-1`. No logic regressions, no security issues.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| infra/cdk/lib/config.ts | Adds optional `openaiEmbeddingModel` field to `DeploymentInputs` interface and resolves it from `OPENAI_EMBEDDING_MODEL` env var — clean, consistent with existing patterns. |
| infra/cdk/lib/pipeline/compute.ts | Wires `deploymentInputs.openaiEmbeddingModel` as an override for `defaultSettings.openai_embedding_model` in `buildLambdaEnvironment`; fallback is equivalent to the previous value, so existing deployments are unaffected. |
| .github/workflows/prod-deploy.yml | Adds `AWS_DEFAULT_REGION` with `us-east-1` fallback and forwards OpenAI / Paddle secrets as job-level env vars so the CDK deploy step picks them up at runtime. |
| .github/workflows/destroy.yml | Adds `AWS_DEFAULT_REGION` alongside `AWS_REGION` (both with `us-east-1` fallback) so AWS SDK tools that read either variable work correctly during teardown. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Actions: prod-deploy.yml] -->|sets OPENAI_EMBEDDING_MODEL env var| B[CDK Deploy Step]
    B --> C[resolveDeploymentInputs\nconfig.ts]
    C -->|reads OPENAI_EMBEDDING_MODEL| D{env var set?}
    D -- Yes --> E[deploymentInputs.openaiEmbeddingModel]
    D -- No --> F[undefined]
    E --> G[buildLambdaEnvironment\ncompute.ts]
    F --> G
    G -->|openaiEmbeddingModel ?? defaultSettings| H[OPENAI_EMBEDDING_MODEL\nLambda env var]
    I[pipeline-config.json\ndefaults.openai_embedding_model] -->|fallback| G
```

<sub>Reviews (1): Last reviewed commit: ["Allow embedding model overrides in deplo..."](https://github.com/owokit/serverless-kb-mcp/commit/a89a49a84e874b57b7032a686cf44702e1e977d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26544637)</sub>

<!-- /greptile_comment -->