### PR TITLE
[codex] 兼容 object_state 表的复合主键 schema

### DIFF
--- a/services/ocr-pipeline/src/serverless_mcp/storage/state/object_state_repository.py
+++ b/services/ocr-pipeline/src/serverless_mcp/storage/state/object_state_repository.py
@@ -17,6 +17,7 @@ from botocore.exceptions import ClientError
 
 from serverless_mcp.domain.models import ObjectStateRecord, S3ObjectRef, utc_now_iso
 
+_STATE_RECORD_TYPE = "STATE"
 _LOOKUP_RECORD_TYPE = "LOOKUP"
 _LOOKUP_RECORD_INDEX_NAME = "lookup-record-type-index"
 
@@ -74,6 +75,7 @@ class ObjectStateRepository:
         # EN: Boto3 DynamoDB client for conditional writes and consistent reads.
         # CN: 用于条件写入和一致性读取的 Boto3 DynamoDB 客户端。
         self._ddb = dynamodb_client
+        self._table_sort_key_name = self._resolve_table_sort_key_name()
 
     def queue_for_ingest(self, source: S3ObjectRef) -> ObjectStateRecord:
         """
@@ -134,7 +136,7 @@ class ObjectStateRepository:
             self._transact_state_and_lookup(
                 update_item={
                     "TableName": self._table_name,
-                    "Key": {"pk": {"S": record.pk}},
+                    "Key": self._build_state_key(record.pk),
                     "UpdateExpression": "SET " + ", ".join(update_parts),
                     "ConditionExpression": condition,
                     "ExpressionAttributeNames": expression_names,
@@ -290,7 +292,7 @@ class ObjectStateRepository:
             self._transact_state_and_lookup(
                 update_item={
                     "TableName": self._table_name,
-                    "Key": {"pk": {"S": source.object_pk}},
+                    "Key": self._build_state_key(source.object_pk),
                     "UpdateExpression": update_expression,
                     "ConditionExpression": condition,
                     "ExpressionAttributeNames": expression_names,
@@ -344,7 +346,7 @@ class ObjectStateRepository:
         """
         response = self._ddb.get_item(
             TableName=self._table_name,
-            Key={"pk": {"S": object_pk}},
+            Key=self._build_state_key(object_pk),
             ConsistentRead=True,
         )
         item = response.get("Item")
@@ -552,7 +554,7 @@ class ObjectStateRepository:
             self._transact_state_and_lookup(
                 update_item={
                     "TableName": self._table_name,
-                    "Key": {"pk": {"S": lookup.object_pk}},
+                    "Key": self._build_state_key(lookup.object_pk),
                     "UpdateExpression": "SET " + ", ".join(parts),
                     "ConditionExpression": condition,
                     "ExpressionAttributeNames": expression_names,
@@ -821,7 +823,7 @@ class ObjectStateRepository:
             self._transact_state_and_lookup(
                 update_item={
                     "TableName": self._table_name,
-                    "Key": {"pk": {"S": source.object_pk}},
+                    "Key": self._build_state_key(source.object_pk),
                     "UpdateExpression": "SET " + ", ".join(parts),
                     "ConditionExpression": "#latest_version_id = :version_id",
                     "ExpressionAttributeNames": expression_names,
@@ -894,13 +896,58 @@ class ObjectStateRepository:
         ):
             response = self._ddb.get_item(
                 TableName=self._table_name,
-                Key={"pk": {"S": pk}},
+                Key=self._build_lookup_key(pk),
                 ConsistentRead=True,
             )
             item = response.get("Item")
             if item:
                 return _deserialize_lookup_record(item)
         return None
+
+    def _resolve_table_sort_key_name(self) -> str | None:
+        """
+        EN: Inspect the DynamoDB table schema once and cache the sort key name when available.
+        CN: 在初始化时缓存表的 sort key，以便所有读写都使用同一种 key 形状。
+        """
+        describe_table = getattr(self._ddb, "describe_table", None)
+        if not callable(describe_table):
+            return None
+        try:
+            response = describe_table(TableName=self._table_name)
+        except Exception:
+            return None
+        key_schema = response.get("Table", {}).get("KeySchema", [])
+        for entry in key_schema:
+            if entry.get("KeyType") != "RANGE":
+                continue
+            attribute_name = entry.get("AttributeName")
+            if isinstance(attribute_name, str) and attribute_name:
+                return attribute_name
+        return None
+
+    def _build_state_key(self, object_pk: str) -> dict[str, dict[str, str]]:
+        """
+        EN: Build a DynamoDB key for an object_state record.
+        CN: 为 object_state 记录构建 DynamoDB key。
+        """
+        return self._build_table_key(object_pk, record_type=_STATE_RECORD_TYPE)
+
+    def _build_lookup_key(self, pk: str) -> dict[str, dict[str, str]]:
+        """
+        EN: Build a DynamoDB key for a lookup record.
+        CN: 为 lookup 记录构建 DynamoDB key。
+        """
+        return self._build_table_key(pk, record_type=_LOOKUP_RECORD_TYPE)
+
+    def _build_table_key(self, pk: str, *, record_type: str) -> dict[str, dict[str, str]]:
+        """
+        EN: Build a DynamoDB key that works for hash-only and composite-state tables.
+        CN: 构建同时适用于 hash-only 和复合主键的 DynamoDB key。
+        """
+        key: dict[str, dict[str, str]] = {"pk": {"S": pk}}
+        if self._table_sort_key_name:
+            key[self._table_sort_key_name] = {"S": record_type}
+        return key
 
 
 def _build_lookup_pk(*, bucket: str, key: str) -> str:
@@ -927,6 +974,7 @@ def _serialize_lookup_record(record: ObjectStateLookupRecord) -> dict[str, dict[
     item: dict[str, dict[str, str | bool]] = {
         "pk": {"S": record.pk},
         "record_type": {"S": _LOOKUP_RECORD_TYPE},
+        "sk": {"S": _LOOKUP_RECORD_TYPE},
         "object_pk": {"S": record.object_pk},
         "tenant_id": {"S": record.tenant_id},
         "bucket": {"S": record.bucket},
@@ -949,6 +997,8 @@ def _serialize_object_state(record: ObjectStateRecord) -> dict[str, dict[str, st
     """
     item: dict[str, dict[str, str | bool]] = {
         "pk": {"S": record.pk},
+        "record_type": {"S": _STATE_RECORD_TYPE},
+        "sk": {"S": _STATE_RECORD_TYPE},
         "latest_version_id": {"S": record.latest_version_id},
         "extract_status": {"S": record.extract_status},
         "embed_status": {"S": record.embed_status},

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py
@@ -35,6 +35,20 @@ class _CapturingDynamoDbClient:
         return {}
 
 
+class _CompositeKeyCapturingDynamoDbClient(_CapturingDynamoDbClient):
+    # EN: Captures a table definition with a record_type sort key.
+    # CN: 鍚屼笂銆?
+    def describe_table(self, **_kwargs):
+        return {
+            "Table": {
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "record_type", "KeyType": "RANGE"},
+                ]
+            }
+        }
+
+
 class _NoWriteDynamoDbClient:
     # EN: DynamoDB client that asserts no write operations are attempted.
     # CN: 同上。
@@ -154,6 +168,33 @@ def test_queue_for_ingest_persists_normalized_sequencer() -> None:
     assert dynamodb.transact_calls[0]["TransactItems"][0]["Update"]["ExpressionAttributeValues"][":sequencer"]["S"] == normalized
     assert dynamodb.transact_calls[0]["TransactItems"][1]["Put"]["Item"]["latest_sequencer"]["S"] == normalized
     assert dynamodb.transact_calls[0]["TransactItems"][1]["Put"]["Item"]["pk"]["S"] == "lookup-v2#bucket-a#docs%2Fguide.pdf"
+
+
+def test_queue_for_ingest_uses_table_sort_key_when_present() -> None:
+    """
+    EN: Queue for ingest should use the table sort key when the DynamoDB schema requires one.
+    CN: 当 DynamoDB 表需要 sort key 时，queue_for_ingest 应该自动带上它。
+    """
+    dynamodb = _CompositeKeyCapturingDynamoDbClient()
+    repo = ObjectStateRepository(table_name="object-state", dynamodb_client=dynamodb)
+    source = S3ObjectRef(
+        tenant_id="tenant-a",
+        bucket="bucket-a",
+        key="docs/guide.pdf",
+        version_id="v1",
+        sequencer="a",
+    )
+
+    record = repo.queue_for_ingest(source)
+
+    assert record.latest_sequencer == _normalize_sequencer("a")
+    assert dynamodb.transact_calls[0]["TransactItems"][0]["Update"]["Key"] == {
+        "pk": {"S": source.object_pk},
+        "record_type": {"S": "STATE"},
+    }
+    lookup_item = dynamodb.transact_calls[0]["TransactItems"][1]["Put"]["Item"]
+    assert lookup_item["record_type"]["S"] == "LOOKUP"
+    assert lookup_item["sk"]["S"] == "LOOKUP"
 
 
 class _ExistingStateRepository(ObjectStateRepository):


### PR DESCRIPTION
## 变更内容
- `ObjectStateRepository` 在运行时读取 DynamoDB 表的 KeySchema，并按实际 sort key 构造 `GetItem` / `UpdateItem` / 事务写入的 Key
- 为 object_state 与 lookup 记录补充稳定的记录类型标识，兼容 hash-only 和复合主键表
- 增加回归测试，覆盖表存在 `record_type` sort key 时的 ingest 路径

## 根因
线上 ingest 报错的直接原因是 `GetItem` 只传了 `pk`，但部署中的表 schema 已经不是纯 hash-only，导致 DynamoDB 返回 `ValidationException: The provided key element does not match the schema`。

## 验证
- `pytest serverless-kb-mcp/services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py -q`
- `pytest serverless-kb-mcp/services/ocr-pipeline/tests/unit/serverless_mcp -q`

## 影响
修复后，Cloudflare 上传到 S3 后触发的 ingest 流程可以继续正常进入 Step Functions，不会在 object_state 读取阶段提前失败。