### PR TITLE
[bug] 补齐 execution-state 表的 Lambda 权限

### DIFF
--- a/infra/cdk/lib/pipeline-stack.ts
+++ b/infra/cdk/lib/pipeline-stack.ts
@@ -36,6 +36,7 @@ export class PipelineStack extends cdk.Stack {
       embedQueue: foundation.embedQueue,
       ingestQueue: foundation.ingestQueue,
       objectStateTable: foundation.objectStateTable,
+      executionStateTable: foundation.executionStateTable,
       manifestIndexTable: foundation.manifestIndexTable,
       embeddingProjectionStateTable: foundation.embeddingProjectionStateTable,
     });

--- a/infra/cdk/lib/pipeline/roles.ts
+++ b/infra/cdk/lib/pipeline/roles.ts
@@ -22,6 +22,7 @@ export interface PipelineRoleParams {
   embedQueue: sqs.Queue;
   ingestQueue: sqs.Queue;
   objectStateTable: dynamodb.Table;
+  executionStateTable: dynamodb.Table;
   manifestIndexTable: dynamodb.Table;
   embeddingProjectionStateTable: dynamodb.Table;
 }
@@ -76,6 +77,10 @@ function attachLambdaDataPlanePolicy(
         resources: [params.objectStateTable.tableArn],
       }),
       new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
+        resources: [params.executionStateTable.tableArn],
+      }),
+      new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
         resources: [params.manifestIndexTable.tableArn],
       }),
@@ -99,6 +104,10 @@ function attachLambdaDataPlanePolicy(
         resources: [params.objectStateTable.tableArn],
       }),
       new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
+        resources: [params.executionStateTable.tableArn],
+      }),
+      new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
         resources: [params.manifestIndexTable.tableArn],
       }),
@@ -116,6 +125,10 @@ function attachLambdaDataPlanePolicy(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:Scan', 'dynamodb:DescribeTable'],
         resources: [params.objectStateTable.tableArn],
+      }),
+      new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
+        resources: [params.executionStateTable.tableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
@@ -139,6 +152,10 @@ function attachLambdaDataPlanePolicy(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:TransactWriteItems', 'dynamodb:UpdateItem', 'dynamodb:DescribeTable'],
         resources: [params.objectStateTable.tableArn],
+      }),
+      new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
+        resources: [params.executionStateTable.tableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
@@ -176,6 +193,10 @@ function attachLambdaDataPlanePolicy(
         resources: [params.objectStateTable.tableArn],
       }),
       new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:DescribeTable'],
+        resources: [params.executionStateTable.tableArn],
+      }),
+      new iam.PolicyStatement({
         actions: ['dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
         resources: [params.manifestIndexTable.tableArn],
       }),
@@ -197,6 +218,10 @@ function attachLambdaDataPlanePolicy(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:Query', 'dynamodb:TransactWriteItems', 'dynamodb:UpdateItem', 'dynamodb:DescribeTable'],
         resources: [params.objectStateTable.tableArn],
+      }),
+      new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:DescribeTable'],
+        resources: [params.executionStateTable.tableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],


### PR DESCRIPTION
## 变更
- 给 `query` / `status` / `backfill` / `ingest` / `extract` / `embed` 的 Lambda 角色补上 `execution_state_table` 的最小 DynamoDB 权限。
- `extract` 和 `embed` 允许 `GetItem` / `PutItem` / `DescribeTable`，其余读路径只保留 `GetItem` / `DescribeTable`。
- 在 `PipelineStack` 里把 `executionStateTable` 传给角色工厂，保证 CDK 模板能生成对应策略。

## 验证
- `MCP_ALLOW_PLACEHOLDER_ASSETS=true npm --prefix infra/cdk run synth`

Closes #18