### PR TITLE
[bug] 默认放行 PaddleOCR 结果 URL 的 BCE BOS 域名

### DIFF
--- a/services/ocr-pipeline/src/serverless_mcp/runtime/config.py
+++ b/services/ocr-pipeline/src/serverless_mcp/runtime/config.py
@@ -15,7 +15,9 @@ from serverless_mcp.embed.provider_urls import normalize_openai_base_url
 from serverless_mcp.domain.models import EmbeddingProfile
 
 
-DEFAULT_PADDLE_OCR_ALLOWED_HOSTS: tuple[str, ...] = ()
+# EN: PaddleOCR result URLs are hosted on BCE BOS regional subdomains by default.
+# CN: PaddleOCR 缁撴灉 URL 榛樿鎸備綅浜庡尯鍩熷瓙鍩熷悕 BCE BOS 銆?
+DEFAULT_PADDLE_OCR_ALLOWED_HOSTS: tuple[str, ...] = ("*.bcebos.com",)
 PIPELINE_CONFIG_PATH_ENV_VAR = "SERVERLESS_MCP_PIPELINE_CONFIG_PATH"
 
 

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_config.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_config.py
@@ -110,7 +110,7 @@ def test_settings_allow_ingest_only_environment(monkeypatch: pytest.MonkeyPatch)
     assert settings.manifest_index_table is None
     assert settings.manifest_bucket is None
     assert settings.manifest_prefix == ""
-    assert settings.paddle_allowed_hosts == ()
+    assert settings.paddle_allowed_hosts == ("*.bcebos.com",)
 
 
 def test_settings_accepts_canonical_state_machine_arn(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -298,7 +298,7 @@ def test_settings_parse_security_controls(monkeypatch: pytest.MonkeyPatch) -> No
 
     settings = Settings.from_env()
 
-    assert settings.paddle_allowed_hosts == ("results.example.com", "*.cdn.example.com")
+    assert settings.paddle_allowed_hosts == ("*.bcebos.com", "results.example.com", "*.cdn.example.com")
     assert settings.allow_unauthenticated_query is False
     assert settings.query_max_top_k == 15
     assert settings.query_max_neighbor_expand == 3
@@ -314,7 +314,7 @@ def test_settings_parse_paddle_allowlist_hosts(monkeypatch: pytest.MonkeyPatch) 
 
     settings = Settings.from_env()
 
-    assert settings.paddle_allowed_hosts == ()
+    assert settings.paddle_allowed_hosts == ("*.bcebos.com",)
 
 
 def test_settings_parse_cloudfront_delivery(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #20

## ????
- ? PaddleOCR ???? URL ???? allowlist?`*.bcebos.com`
- ?????????? `https`??????? `*`
- ??????????????? allowlist ????

## ????
- ??????`services/ocr-pipeline/src/serverless_mcp/runtime/config.py`
- ??????`services/ocr-pipeline/tests/unit/serverless_mcp/test_config.py`
- ??????`PersistOcrResult` -> `download_json_lines()` -> PaddleOCR ????

## ??
- `uv run --project services pytest services/ocr-pipeline/tests/unit/serverless_mcp -q`
- ???`252 passed`

## ??
- ??? `*.bcebos.com`?????????
- ???? `PADDLE_OCR_ALLOWED_HOSTS` ????????????
