### PR TITLE
[bug] 处理 PersistOcrResult 的 DynamoDB 事务条件失败

### DIFF
--- a/services/ocr-pipeline/src/serverless_mcp/storage/state/object_state_repository.py
+++ b/services/ocr-pipeline/src/serverless_mcp/storage/state/object_state_repository.py
@@ -156,7 +156,7 @@ class ObjectStateRepository:
                 ),
             )
         except ClientError as exc:
-            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            if _is_duplicate_or_stale_dynamodb_error(exc):
                 raise DuplicateOrStaleEventError(source.document_uri) from exc
             raise
 
@@ -312,7 +312,7 @@ class ObjectStateRepository:
                 ),
             )
         except ClientError as exc:
-            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            if _is_duplicate_or_stale_dynamodb_error(exc):
                 raise DuplicateOrStaleEventError(source.document_uri) from exc
             raise
 
@@ -574,7 +574,7 @@ class ObjectStateRepository:
                 ),
             )
         except ClientError as exc:
-            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            if _is_duplicate_or_stale_dynamodb_error(exc):
                 raise DuplicateOrStaleEventError(f"s3://{bucket}/{key}?versionId={version_id}") from exc
             raise
 
@@ -843,7 +843,7 @@ class ObjectStateRepository:
                 ),
             )
         except ClientError as exc:
-            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            if _is_duplicate_or_stale_dynamodb_error(exc):
                 raise DuplicateOrStaleEventError(source.document_uri) from exc
             raise
 
@@ -1116,6 +1116,28 @@ def _prefer_lookup_record(candidate: ObjectStateLookupRecord, current: ObjectSta
     if candidate_is_legacy != current_is_legacy:
         return not candidate_is_legacy
     return candidate.updated_at >= current.updated_at
+
+
+def _is_duplicate_or_stale_dynamodb_error(exc: ClientError) -> bool:
+    """
+    EN: Recognize duplicate/stale conditional write failures, including transactional wrappers.
+    CN: 识别重复/过期导致的条件写失败，也兼容事务包装后的异常。
+    """
+    error = exc.response.get("Error", {})
+    code = error.get("Code")
+    if code == "ConditionalCheckFailedException":
+        return True
+    if code != "TransactionCanceledException":
+        return False
+
+    cancellation_reasons = exc.response.get("CancellationReasons")
+    if isinstance(cancellation_reasons, list):
+        for reason in cancellation_reasons:
+            if isinstance(reason, dict) and reason.get("Code") == "ConditionalCheckFailed":
+                return True
+
+    message = error.get("Message")
+    return isinstance(message, str) and "ConditionalCheckFailed" in message
 
 
 def _is_legacy_lookup_pk(pk: str) -> bool:

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py
@@ -3,9 +3,15 @@ EN: Tests for ObjectStateRepository covering ingest queuing, state activation, d
 CN: 同上。
 """
 
+import re
+
+import pytest
+from botocore.exceptions import ClientError
+
 from serverless_mcp.domain.models import ObjectStateRecord, S3ObjectRef
 from serverless_mcp.storage.state.object_state_repository import (
     ObjectStateLookupRecord,
+    DuplicateOrStaleEventError,
     ObjectStateRepository,
     _normalize_sequencer,
 )
@@ -66,6 +72,22 @@ class _NoWriteDynamoDbClient:
 
     def transact_write_items(self, **_kwargs):
         raise AssertionError("transact_write_items should not be called for delete-marker replay")
+
+
+class _TransactionCanceledDynamoDbClient(_NoWriteDynamoDbClient):
+    # EN: DynamoDB client that raises a transaction-canceled conditional failure.
+    # CN: 鍚屼笂銆?
+    def transact_write_items(self, **_kwargs):
+        raise ClientError(
+            {
+                "Error": {
+                    "Code": "TransactionCanceledException",
+                    "Message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed, None]",
+                },
+                "CancellationReasons": [{"Code": "ConditionalCheckFailed"}, {"Code": "None"}],
+            },
+            "TransactWriteItems",
+        )
 
 
 class _LookupQueryDynamoDbClient:
@@ -289,6 +311,34 @@ def test_activate_ingest_state_reuses_existing_extracting_state_without_new_writ
     )
 
     assert record is existing
+
+
+def test_mark_extract_done_treats_transaction_canceled_conditional_failure_as_duplicate_or_stale() -> None:
+    """
+    EN: Mark extract done treats transaction canceled conditional failure as duplicate or stale.
+    CN: 鍚屼笂銆?
+    """
+    source = S3ObjectRef(
+        tenant_id="tenant-a",
+        bucket="bucket-a",
+        key="docs/guide.pdf",
+        version_id="v1",
+        sequencer="1",
+    )
+    repo = _ExistingStateRepository(
+        state=ObjectStateRecord(
+            pk=source.object_pk,
+            latest_version_id=source.version_id,
+            latest_sequencer=_normalize_sequencer("1"),
+            extract_status="EXTRACTING",
+            embed_status="PENDING",
+            latest_manifest_s3_uri="s3://manifest-bucket/manifests/in-progress.json",
+        ),
+        dynamodb_client=_TransactionCanceledDynamoDbClient(),
+    )
+
+    with pytest.raises(DuplicateOrStaleEventError, match=re.escape(source.document_uri)):
+        repo.mark_extract_done(source, "s3://manifest-bucket/manifests/final.json")
 
 
 def test_mark_deleted_replays_same_delete_marker_without_new_write() -> None:


### PR DESCRIPTION
Closes #22

## ????
- ? `ObjectStateRepository` ?????????????? helper
- ?? `ConditionalCheckFailedException` ? `TransactionCanceledException`
- ? `PersistOcrResult` ? `mark_extract_done()` ????????????????????????

## ????
- `services/ocr-pipeline/src/serverless_mcp/storage/state/object_state_repository.py`
- `services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py`
- ??????`PersistOcrResult` -> `mark_extract_done()` -> DynamoDB ????

## ??
- `uv run --project services pytest services/ocr-pipeline/tests/unit/serverless_mcp/test_object_state_repository.py -q`
- `uv run --project services pytest services/ocr-pipeline/tests/unit/serverless_mcp -q`
- ???`253 passed`

## ??
- ??????????????? `DuplicateOrStaleEventError`
- ????????? DynamoDB ????
