### PR TITLE
[bug] PersistOcrResult 的重复/过期事件应跳过而不是失败

### DIFF
--- a/services/ocr-pipeline/src/serverless_mcp/extract/pipeline.py
+++ b/services/ocr-pipeline/src/serverless_mcp/extract/pipeline.py
@@ -1,6 +1,6 @@
 """
 EN: Extraction result persister that writes manifest to S3 and dispatches embed jobs.
-CN: 将提取结果持久化到 S3 manifest，并分发 embed 作业的持久化器。
+CN: 灏嗘彁鍙栫粨鏋滄寔涔呭寲鍒?S3 manifest锛屽苟鍒嗗彂 embed 浣滀笟鐨勬寔涔呭寲鍣ㄣ€?
 """
 from __future__ import annotations
 
@@ -23,15 +23,16 @@ from serverless_mcp.storage.state.object_state_repository import DuplicateOrStal
 
 
 _DISPATCH_FAILURE_TYPES = (ClientError, KeyError, OSError, RuntimeError, TypeError, ValueError)
+_PERSIST_PREPARATION_FAILURE_TYPES = (ClientError, KeyError, OSError, RuntimeError, TypeError, ValueError)
 
 
 class ExtractionResultPersister:
     """
     EN: Persist extraction manifest to S3 manifest bucket and dispatch embedding jobs to SQS.
-    CN: 将提取 manifest 持久化到 S3 manifest bucket，并把 embedding 作业分发到 SQS。
+    CN: 灏嗘彁鍙?manifest 鎸佷箙鍖栧埌 S3 manifest bucket锛屽苟鎶?embedding 浣滀笟鍒嗗彂鍒?SQS銆?
 
     This component owns the boundary between extract and embed phases.
-    该组件负责提取阶段与嵌入阶段之间的边界。
+    璇ョ粍浠惰礋璐ｆ彁鍙栭樁娈典笌宓屽叆闃舵涔嬮棿鐨勮竟鐣屻€?
     """
 
     def __init__(
@@ -62,28 +63,28 @@ class ExtractionResultPersister:
     ) -> ProcessingOutcome:
         """
         EN: Extract stage only persists manifest and dispatches whole-document embed job, not writing vectors directly.
-        CN: 提取阶段只持久化 manifest 并分发整篇文档的 embed 作业，不会直接写入向量。
+        CN: 鎻愬彇闃舵鍙寔涔呭寲 manifest 骞跺垎鍙戞暣绡囨枃妗ｇ殑 embed 浣滀笟锛屼笉浼氱洿鎺ュ啓鍏ュ悜閲忋€?
 
         Args:
             source:
                 EN: S3 object reference with bucket/key/version_id identity.
-                CN: 通过 bucket、key 和 version_id 标识的 S3 对象引用。
+                CN: 閫氳繃 bucket銆乲ey 鍜?version_id 鏍囪瘑鐨?S3 瀵硅薄寮曠敤銆?
             manifest:
                 EN: Chunk manifest containing text chunks and asset references.
-                CN: 包含文本 chunk 和资源引用的 chunk manifest。
+                CN: 鍖呭惈鏂囨湰 chunk 鍜岃祫婧愬紩鐢ㄧ殑 chunk manifest銆?
             trace_id:
                 EN: Trace identifier for request correlation.
-                CN: 用于请求关联的 trace 标识。
+                CN: 鐢ㄤ簬璇锋眰鍏宠仈鐨?trace 鏍囪瘑銆?
             previous_version_id:
                 EN: Previous version_id for version progression tracking.
-                CN: 用于版本推进跟踪的 previous_version_id。
+                CN: 鐢ㄤ簬鐗堟湰鎺ㄨ繘璺熻釜鐨?previous_version_id銆?
             previous_manifest_s3_uri:
                 EN: Previous manifest S3 URI for version chain.
-                CN: 版本链中上一份 manifest 的 S3 URI。
+                CN: 鐗堟湰閾句腑涓婁竴浠?manifest 鐨?S3 URI銆?
 
         Returns:
             EN: Processing outcome with manifest URI and chunk counts.
-            CN: 包含 manifest URI 和 chunk 计数的处理结果。
+            CN: 鍖呭惈 manifest URI 鍜?chunk 璁℃暟鐨勫鐞嗙粨鏋溿€?
         """
         current_state = self._object_state_repo.get_state(object_pk=source.object_pk)
         if current_state is not None and (
@@ -100,22 +101,30 @@ class ExtractionResultPersister:
             manifest,
             previous_version_id=previous_version_id,
         )
-        embedding_requests = self._extraction_service.build_embedding_requests(
-            persisted.manifest,
-            manifest_s3_uri=persisted.manifest_s3_uri,
-        )
-        validate_embedding_requests(embedding_requests)
-        # EN: Fan out one embed job per enabled profile so each vector index is populated independently.
-        # CN: 为每个已启用的 profile 分发一份 embed 作业，让各自的向量索引独立填充。
-        embedding_jobs = build_jobs_for_profiles(
-            source=source,
-            trace_id=trace_id,
-            manifest_s3_uri=persisted.manifest_s3_uri,
-            requests=embedding_requests,
-            profiles=self._embedding_profiles,
-            previous_version_id=previous_version_id,
-            previous_manifest_s3_uri=previous_manifest_s3_uri,
-        )
+        try:
+            embedding_requests = self._extraction_service.build_embedding_requests(
+                persisted.manifest,
+                manifest_s3_uri=persisted.manifest_s3_uri,
+            )
+            validate_embedding_requests(embedding_requests)
+            # EN: Fan out one embed job per enabled profile so each vector index is populated independently.
+            # CN: 涓烘瘡涓凡鍚敤鐨?profile 鍒嗗彂涓€浠?embed 浣滀笟锛岃鍚勮嚜鐨勫悜閲忕储寮曠嫭绔嬪～鍏呫€?
+            embedding_jobs = build_jobs_for_profiles(
+                source=source,
+                trace_id=trace_id,
+                manifest_s3_uri=persisted.manifest_s3_uri,
+                requests=embedding_requests,
+                profiles=self._embedding_profiles,
+                previous_version_id=previous_version_id,
+                previous_manifest_s3_uri=previous_manifest_s3_uri,
+            )
+        except _PERSIST_PREPARATION_FAILURE_TYPES:
+            self._manifest_repo.rollback_manifest(
+                persisted.manifest,
+                manifest_s3_uri=persisted.manifest_s3_uri,
+                previous_version_id=previous_version_id,
+            )
+            raise
         try:
             self._embed_dispatcher.dispatch_many(embedding_jobs)
         except _DISPATCH_FAILURE_TYPES:
@@ -159,7 +168,7 @@ class ExtractionResultPersister:
     ) -> ProcessingOutcome:
         """
         EN: Build a benign skip outcome when extract state is already stale or complete.
-        CN: 褰撴彁鍙栫姸鎬佸凡杩囨湡鎴栧凡瀹屾垚鏃舵瀯寤鸿鍙风殑骞冲拰璺勮繃缁撴灉銆?
+        CN: 瑜版挻褰侀崣鏍Ц閹礁鍑℃潻鍥ㄦ埂閹存牕鍑＄€瑰本鍨氶弮鑸电€楦款暙閸欓娈戦獮鍐叉嫲鐠哄嫯绻冪紒鎾寸亯閵?
         """
         if object_state is None:
             object_state = ObjectStateRecord(

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_pipeline.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_pipeline.py
@@ -288,6 +288,70 @@ def test_persister_skips_when_mark_extract_done_detects_duplicate_or_stale_event
     assert len(dispatcher.jobs) == 1
 
 
+def test_persister_rolls_back_manifest_when_embedding_request_build_fails() -> None:
+    """
+    EN: Persist should roll back a manifest if request construction fails after the manifest is written.
+    CN: 当 manifest 已写入但后续请求构建失败时，persist 应回滚 manifest。
+    """
+    class _FailingExtractionService:
+        def build_embedding_requests(self, manifest, *, manifest_s3_uri):
+            raise ValueError("bad embedding request")
+
+    source = S3ObjectRef(tenant_id="tenant-a", bucket="bucket-a", key="docs/guide.pdf", version_id="v1")
+    manifest_repo = _FakeManifestRepo()
+    persister = ExtractionResultPersister(
+        extraction_service=_FailingExtractionService(),
+        object_state_repo=_FakeObjectStateRepo(
+            current_state=ObjectStateRecord(
+                pk=source.object_pk,
+                latest_version_id=source.version_id,
+                latest_sequencer=source.sequencer,
+                extract_status="EXTRACTING",
+                embed_status="PENDING",
+            )
+        ),
+        manifest_repo=manifest_repo,
+        embed_dispatcher=_FakeDispatcher(),
+        embedding_profiles=(
+            EmbeddingProfile(
+                profile_id="gemini-default",
+                provider="gemini",
+                model="gemini-embedding-2-preview",
+                dimension=3072,
+                vector_bucket_name="vector-bucket",
+                vector_index_name="index-gemini",
+                supported_content_kinds=("text", "image"),
+            ),
+        ),
+    )
+
+    try:
+        persister.persist(
+            source=source,
+            manifest=ChunkManifest(
+                source=source,
+                doc_type="pdf",
+                chunks=[
+                    ExtractedChunk(
+                        chunk_id="chunk#000001",
+                        chunk_type="page_text_chunk",
+                        text="hello",
+                        doc_type="pdf",
+                        token_estimate=2,
+                    )
+                ],
+            ),
+            trace_id="trace-1",
+        )
+    except ValueError as exc:
+        assert str(exc) == "bad embedding request"
+    else:
+        raise AssertionError("embedding request validation failure should surface to the caller")
+
+    assert manifest_repo.persist_calls == [(source.document_uri, None)]
+    assert manifest_repo.rollback_calls == [(source.document_uri, "s3://manifest-bucket/manifests/example.json", None)]
+
+
 def test_persister_passes_previous_version_id_to_manifest_repo() -> None:
     """
     EN: Persister passes previous version id to manifest repo.


### PR DESCRIPTION
## 背景\n\nCloudWatch / X-Ray 显示 PersistOcrResult 在 mark_extract_done() 阶段遇到 DuplicateOrStaleEventError 后仍然把 Lambda 打成失败。这个错误本身代表幂等/过期事件，不应该继续向上冒泡。\n\n## 变更\n\n- 在 ExtractionResultPersister.persist() 里先读取当前状态，若已经不是同一版本或不再处于 EXTRACTING，直接返回跳过结果。\n- 在最终 mark_extract_done() 处再补一层 DuplicateOrStaleEventError 兜底，避免并发竞争把流程打断。\n- 新增回归测试，覆盖：\n  - 预先已过期的状态直接跳过\n  - 最终状态写入时发现重复/过期事件时返回跳过\n\n## 验证\n\n- python -m pytest services/ocr-pipeline/tests/unit/serverless_mcp/test_pipeline.py -q\n- python -m pytest services/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py -q\n- python -m pytest services/ocr-pipeline/tests/unit/serverless_mcp/test_extract_handler.py -q\n\nCloses #24