### PR TITLE
[bug] 修复 Embed Lambda 的 OpenAI embeddings 解析异常

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AWS_REGION: ${{ inputs.region || secrets.AWS_REGION || 'us-east-1' }}
-      AWS_DEFAULT_REGION: ${{ inputs.region || secrets.AWS_REGION || 'us-east-1' }}
+      AWS_REGION: ${{ inputs.region || secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ inputs.region || secrets.AWS_REGION }}
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/services/ocr-pipeline/src/serverless_mcp/embed/backfill_request.py
+++ b/services/ocr-pipeline/src/serverless_mcp/embed/backfill_request.py
@@ -31,9 +31,9 @@ def build_backfill_request(event: dict[str, Any], *, settings: Settings | None =
     EN: Parse the backfill invocation payload into a stable job request contract.
     CN: 将 backfill 调用负载解析为稳定的作业请求契约。
     """
-    active_settings = settings or load_settings()
     profile_id = str(event.get("profile_id") or "").strip()
     if not profile_id:
+        active_settings = settings or load_settings()
         profiles = list(get_write_profiles(active_settings))
         if len(profiles) != 1:
             raise ValueError("profile_id is required when more than one writable embedding profile is configured")

--- a/services/ocr-pipeline/src/serverless_mcp/embed/openai_client.py
+++ b/services/ocr-pipeline/src/serverless_mcp/embed/openai_client.py
@@ -4,6 +4,11 @@ CN: 兼容 OpenAI 的纯文本 embedding 客户端。
 """
 from __future__ import annotations
 
+import base64
+import json
+import struct
+
+import httpx
 from openai import OpenAI
 
 from serverless_mcp.domain.models import EmbeddingRequest
@@ -12,8 +17,8 @@ from serverless_mcp.embed.provider_urls import normalize_openai_base_url
 
 class OpenAIEmbeddingClient:
     """
-    EN: OpenAI-compatible embedding client that delegates to the official OpenAI SDK for text-only embeddings.
-    CN: 兼容 OpenAI 的 embedding 客户端，使用官方 OpenAI SDK 处理纯文本 embedding。
+    EN: OpenAI-compatible embedding client that delegates request execution to the official OpenAI SDK.
+    CN: 通过官方 OpenAI SDK 执行请求的 OpenAI 兼容 embedding 客户端。
     """
 
     def __init__(
@@ -49,7 +54,7 @@ class OpenAIEmbeddingClient:
 
     def embed_text(self, request: EmbeddingRequest) -> list[float]:
         """
-        EN: Generate an embedding vector for the given text-only request via the OpenAI API.
+        EN: Generate an embedding vector for the given text-only request.
         CN: 通过 OpenAI API 为给定的纯文本请求生成 embedding 向量。
 
         Args:
@@ -68,24 +73,28 @@ class OpenAIEmbeddingClient:
         if not request.text:
             raise ValueError("Text embedding request requires text")
 
-        response = self._client.embeddings.create(
+        response = self._client.embeddings.with_raw_response.create(
             model=self._model,
             input=request.text,
             dimensions=request.output_dimensionality,
+            encoding_format="float",
             timeout=self._timeout_seconds,
         )
-        data = response.data or []
+        payload = self._parse_response_payload(response.http_response)
+        data = payload.get("data") or []
         if not data:
             raise ValueError("OpenAI embedding response does not contain data")
-        embedding = data[0].embedding or []
+
+        first = data[0]
+        embedding = first.get("embedding") if isinstance(first, dict) else getattr(first, "embedding", None)
         if not embedding:
             raise ValueError("OpenAI embedding response does not contain embedding")
-        return [float(value) for value in embedding]
+        return self._coerce_embedding_values(embedding)
 
     def embed_bytes(self, *, payload: bytes, mime_type: str, request: EmbeddingRequest) -> list[float]:
         """
-        EN: Not supported – OpenAI client in this repository only handles text embeddings.
-        CN: 不支持，这个仓库里的 OpenAI 客户端只处理文本 embedding。
+        EN: Not supported - OpenAI client in this repository only handles text embeddings.
+        CN: 不支持，本仓库里的 OpenAI 客户端只处理文本 embedding。
 
         Raises:
             EN: ValueError always, because binary embedding is unsupported.
@@ -93,3 +102,37 @@ class OpenAIEmbeddingClient:
         """
         raise ValueError("OpenAI embedding client does not support binary content in this repository")
 
+    @staticmethod
+    def _parse_response_payload(response: httpx.Response) -> dict[str, object]:
+        """
+        EN: Parse an embedding response payload regardless of the response content type.
+        CN: 不管响应内容类型如何，都解析 embedding 响应载荷。
+        """
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            content_type = response.headers.get("content-type", "<missing>")
+            raise ValueError(
+                f"OpenAI embedding response is not valid JSON (content-type={content_type})"
+            ) from exc
+
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if not isinstance(payload, dict):
+            raise ValueError("OpenAI embedding response must be a JSON object")
+        return payload
+
+    @staticmethod
+    def _coerce_embedding_values(embedding: object) -> list[float]:
+        """
+        EN: Convert embedding values to a list of floats, accepting either numeric lists or base64 payloads.
+        CN: 将 embedding 值统一转成 float 列表，同时支持数值列表或 base64 载荷。
+        """
+        if isinstance(embedding, (list, tuple)):
+            return [float(value) for value in embedding]
+        if isinstance(embedding, str):
+            raw = base64.b64decode(embedding)
+            if len(raw) % 4 != 0:
+                raise ValueError("OpenAI embedding base64 payload length is invalid")
+            return [float(value) for value in struct.unpack(f"<{len(raw) // 4}f", raw)]
+        raise ValueError(f"OpenAI embedding response contains unsupported embedding type: {type(embedding).__name__}")

--- a/services/ocr-pipeline/src/serverless_mcp/entrypoints/backfill.py
+++ b/services/ocr-pipeline/src/serverless_mcp/entrypoints/backfill.py
@@ -12,7 +12,6 @@ from aws_lambda_powertools import Logger
 
 from serverless_mcp.runtime.embed_runtime import build_backfill_service
 from serverless_mcp.core.serialization import error_response
-from serverless_mcp.embed.backfill_request import build_backfill_request
 from serverless_mcp.runtime.observability import emit_trace
 
 _logger = Logger(service=os.environ.get("POWERTOOLS_SERVICE_NAME", "serverless-mcp-service"))
@@ -39,6 +38,8 @@ def lambda_handler(event: dict, _context) -> dict:
             error_message="profile_id is required for backfill worker",
         )
         return error_response(400, "profile_id is required for backfill worker")
+
+    from serverless_mcp.embed.backfill_request import build_backfill_request
 
     request = build_backfill_request(event)
     backfill_kwargs = {

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_openai_client.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_openai_client.py
@@ -1,28 +1,47 @@
 """
 EN: Tests for OpenAIEmbeddingClient SDK integration.
-CN: 娴嬭瘯 OpenAIEmbeddingClient SDK 闆嗘垚銆?
+CN: OpenAIEmbeddingClient SDK 集成测试。
 """
 
 from __future__ import annotations
 
-from serverless_mcp.embed import openai_client
+import json
+import types
+
+import httpx
+
 from serverless_mcp.domain.models import EmbeddingRequest
+from serverless_mcp.embed import openai_client
+
+
+class _FakeRawResponse:
+    def __init__(self, payload: dict[str, object], *, content_type: str = "text/plain") -> None:
+        self.http_response = httpx.Response(
+            200,
+            headers={"content-type": content_type},
+            content=json.dumps(payload).encode("utf-8"),
+        )
+
+
+class _FakeEmbeddings:
+    def __init__(self) -> None:
+        self.calls = []
+        self.with_raw_response = types.SimpleNamespace(create=self.create)
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return _FakeRawResponse({"data": [{"embedding": [0.1, 0.2]}]}, content_type="text/plain")
 
 
 class _FakeOpenAI:
     def __init__(self) -> None:
-        self.embeddings = self
-        self.calls = []
-
-    def create(self, **kwargs):
-        self.calls.append(kwargs)
-        return type("Response", (), {"data": [type("Embedding", (), {"embedding": [0.1, 0.2]})()]})()
+        self.embeddings = _FakeEmbeddings()
 
 
-def test_openai_embedding_client_uses_sdk_embeddings(monkeypatch) -> None:
+def test_openai_embedding_client_uses_raw_response_and_float_encoding(monkeypatch) -> None:
     """
-    EN: Openai embedding client uses sdk embeddings.
-    CN: 同上。
+    EN: OpenAI embedding client uses raw response parsing and float encoding.
+    CN: 验证 OpenAI embedding 客户端使用 raw response 解析和 float 编码。
     """
     captured = {}
     fake = _FakeOpenAI()
@@ -55,13 +74,13 @@ def test_openai_embedding_client_uses_sdk_embeddings(monkeypatch) -> None:
         "base_url": "https://api.openai.com/v1/",
         "timeout": 45,
     }
-    assert fake.calls == [
+    assert fake.embeddings.calls == [
         {
             "model": "text-embedding-3-small",
             "input": "hello world",
             "dimensions": 1536,
+            "encoding_format": "float",
             "timeout": 45,
         }
     ]
     assert vector == [0.1, 0.2]
-


### PR DESCRIPTION
Closes #30

## 变更摘要
- 问题是：Embed Lambda 调用 OpenAI embeddings 时，OpenAI SDK 在响应解析阶段把非 JSON 响应当成字符串处理，触发 `AttributeError: 'str' object has no attribute 'data'`。
- 为什么要改：生产环境 embed worker 因响应内容类型不兼容而反复失败，阻断向量入库。
- 这次改了什么：改用 raw response 读取 OpenAI embeddings，并手动解析 JSON / embedding 值；同时补充回归测试。
- 没有改什么：没有改 S3 / Step Functions / 向量仓库的主流程协议。
- 对外可见结果：embed Lambda 可以继续完成文本向量化，不再被 SDK 的 typed parser 卡死。

## 关联 Issue
- 关联 issue：#30
- 关闭关系：本 PR 完整覆盖该 issue。

## 变更类型
- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [x] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围
- 受影响的目录：`services/ocr-pipeline/src/serverless_mcp/embed/`、`services/ocr-pipeline/src/serverless_mcp/entrypoints/`、`services/ocr-pipeline/tests/unit/serverless_mcp/`、`.github/workflows/`
- 受影响的模块 / 服务：OpenAI embedding client、backfill handler、destroy workflow
- 受影响的 workflow：`destroy.yml`
- 受影响的数据 / 状态：embed 请求响应解析、backfill settings 装配
- 是否影响默认 PR 门禁：会影响，因为新增 / 变更代码必须通过全量测试
- 是否影响部署 / 回滚：不会改变部署拓扑，只修正运行时兼容性

## 详细说明
### 1. 主要改动
- `openai_client.py` 改为使用 `with_raw_response.create(...)`，避免 OpenAI SDK 的 typed parser 因内容类型异常返回字符串而崩溃。
- 新增对 raw HTTP 响应的 JSON 解析和 embedding 值转换，兼容 float 列表与 base64 载荷。
- `backfill_request.py` 改为在确实需要回退推导 `profile_id` 时才加载 settings，避免显式 `profile_id` 场景下无谓依赖环境变量。
- `entrypoints/backfill.py` 将 `build_backfill_request` 改为函数内导入，避免 `test_embed_runtime_imports` 清空模块缓存后 monkeypatch 失效。
- `destroy.yml` 移除了 `AWS_REGION` / `AWS_DEFAULT_REGION` 的硬编码 `us-east-1` 回退，和现有 workflow 测试保持一致。

### 2. 设计选择
- 为什么采用 raw response：可以绕开 SDK 内部 `obj.data` 的 post-parser 崩溃，同时保留 OpenAI SDK 作为 HTTP 客户端。
- 备选方案是什么：继续依赖 typed parser，或切回自写 HTTP 请求。
- 为什么没有选择备选方案：raw response 改动更小，仍然复用官方 SDK 的连接、认证和重试能力。

### 3. 兼容性
- 是否向后兼容：是，输入输出契约不变。
- 是否需要迁移：不需要。
- 是否需要重建索引 / 重新部署 / 重新生成产物：不需要。
- 是否引入新环境变量 / 新配置项：不需要。

### 4. 文件清单
- 修改文件：
  - `services/ocr-pipeline/src/serverless_mcp/embed/openai_client.py`
  - `services/ocr-pipeline/src/serverless_mcp/embed/backfill_request.py`
  - `services/ocr-pipeline/src/serverless_mcp/entrypoints/backfill.py`
  - `services/ocr-pipeline/tests/unit/serverless_mcp/test_openai_client.py`
  - `.github/workflows/destroy.yml`
- 新增文件：无
- 删除文件：无

## 验证
### 本地验证
- 执行的命令：`uv run --project services pytest`
- 命令输出结论：`307 passed, 2 skipped`
- 相关截图 / 日志 / 链接：无

### 自动化验证
- [x] 单元测试
- [ ] 集成测试
- [ ] 静态检查
- [x] 构建检查
- [x] workflow / CI 检查
- [ ] 其他

### 验证结果
- 通过项：`uv run --project services pytest`、`uv run --project services ruff check`
- 失败项：无
- 未执行项及原因：无

## 风险与回滚
- 主要风险：如果上游 OpenAI 兼容端点返回的 JSON 结构进一步偏离 embeddings 规范，需要再补充解析兼容。
- 风险缓解方式：保留明确的 payload 校验和错误信息，测试覆盖 text/plain + JSON 兼容场景。
- 回滚方式：回退该提交即可。
- 回滚后遗留影响：embed Lambda 重新回到当前解析失败状态。
- 是否需要灰度：不需要。

## 对业务 / 运维的影响
- 是否影响线上行为：会修复线上 embedding 失败。
- 是否影响部署流程：轻微，`destroy.yml` 与测试保持一致。
- 是否影响监控 / 告警：不需要新增。
- 是否影响成本 / 性能：变化很小，raw response 解析开销可忽略。
- 是否影响运维手册：不需要。

## 截图 / 录屏 / 示例
- 截图：无
- 录屏：无
- 示例输入：无
- 示例输出：无

## 待确认事项
- [x] 根因或假设已明确
- [x] 修复方案已明确
- [x] 验证方式已明确
- [x] 回滚或缓解方案已记录
- [x] 相关 sub issue 已关闭

## Reviewer 关注点
- 请重点检查：OpenAI raw response 解析是否足够稳妥，`backfill` 入口的 lazy import 是否会影响正常运行。
- 请重点验证：`destroy.yml` 的 region 回退去除后是否符合当前发布规则。
- 请重点确认：没有引入新的环境变量或部署约束。

## 提交前自检
- [x] PR 正文已按模板完整填写
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #30`
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看 GitHub 上实际显示的标题、正文和模板字段