### PR TITLE
[bug] 修复 OpenRouter OpenAI 兼容 embeddings 的 base URL 归一化错误

### DIFF
--- a/docs/deployment-config-single-source-of-truth.md
+++ b/docs/deployment-config-single-source-of-truth.md
@@ -1,6 +1,6 @@
-# 部署配置单一来源
+﻿# 部署配置单一来源
 
-`pipeline-config.json` 仍然是仓库里部署命名和默认值的唯一配置源。现在它由 TypeScript CDK 读取，并同时服务于：
+`pipeline-config.json` 仍然是仓库里部署命名和默认值的唯一配置源。它现在被以下位置共同读取：
 
 - `infra/bin/app.ts`
 - `infra/lib/pipeline-stack.ts`
@@ -16,6 +16,7 @@
 - `defaults` 保存运行时默认值，例如 Lambda 超时、OCR 参数和查询阈值
 - `lambda_settings` 保存每个 Lambda 函数的内存和超时设置
 - OpenAI 兼容 base URL 的主入口是 `OPENAI_API_BASE_URL`，不再接受 `OPENAI_BASE_URL` 兼容别名；`AZURE_OPENAI_URL` 不再使用
+- 如果兼容端点本身带有自定义路径前缀，例如 OpenRouter 的 `/api/v1`，运行时必须保留该前缀，不要再强行规范化成 `/v1`
 - 仓库检查入的 `.env.example` 也指向仓库根目录的 `pipeline-config.json`，不要再推荐 `scripts/deploy/pipeline-config.json`
 
 ## 现在的消费方式
@@ -28,5 +29,5 @@
 
 - 任何会影响资源命名、默认值或 embedding profile 的改动，都必须先改 `pipeline-config.json`
 - 不要在不同脚本里复制一份新的默认值
-- 删除旧 helper 后，配置文件仍然保留为唯一事实来源，不要把默认值散落到 workflow 或脚本参数里
-- 如果需要调整 OpenAI 兼容端点，请只更新 `OPENAI_API_BASE_URL`
+- 删除旧 helper 之后，配置文件仍然是唯一事实来源，不要把默认值散落到 workflow 或脚本参数里
+- 如果要调整 OpenAI 兼容端点，请只更新 `OPENAI_API_BASE_URL`

--- a/services/ocr-pipeline/src/serverless_mcp/embed/provider_urls.py
+++ b/services/ocr-pipeline/src/serverless_mcp/embed/provider_urls.py
@@ -13,8 +13,8 @@ _GEMINI_VERSION_SUFFIXES = ("/v1beta", "/v1")
 
 def normalize_openai_base_url(base_url: str) -> str:
     """
-    EN: Normalize OpenAI-compatible base URLs so Azure and public OpenAI both work with root or versioned inputs.
-    CN: 规范化 OpenAI 兼容 base URL，使 Azure 与公网 OpenAI 都能兼容根路径或带版本路径的输入。
+    EN: Normalize OpenAI-compatible base URLs while preserving explicit custom path prefixes.
+    CN: 规范化 OpenAI 兼容 base URL，但保留显式配置的自定义路径前缀。
     """
     parsed = _parse_absolute_url(base_url)
     host = parsed.netloc.lower()
@@ -22,13 +22,11 @@ def normalize_openai_base_url(base_url: str) -> str:
 
     if _is_azure_openai_host(host):
         normalized_path = "/openai/v1"
-    elif raw_path.endswith("/openai/v1"):
-        normalized_path = "/openai/v1"
-    elif raw_path.endswith("/v1"):
-        normalized_path = "/v1"
     elif _is_public_openai_host(host):
         normalized_path = "/v1"
     elif raw_path:
+        # EN: Preserve caller-provided prefixes such as /api/v1 for OpenRouter and similar providers.
+        # CN: 保留调用方显式提供的路径前缀，例如 OpenRouter 及类似服务的 /api/v1。
         normalized_path = raw_path
     else:
         normalized_path = "/v1"
@@ -52,13 +50,13 @@ def normalize_gemini_base_url(base_url: str) -> str:
 
     Raises:
         EN: ValueError if the URL is not absolute (missing scheme or host).
-        CN: 当 URL 非绝对路径（缺少 scheme 或 host）时抛出 ValueError。
+        CN: 当 URL 不是绝对路径（缺少 scheme 或 host）时抛出 ValueError。
     """
     parsed = _parse_absolute_url(base_url)
     raw_path = (parsed.path or "").rstrip("/")
 
     # EN: Strip known Gemini version suffixes so the SDK can layer its own apiVersion.
-    # CN: 剥离已知的 Gemini 版式后缀，以便 SDK 自行附加 apiVersion。
+    # CN: 剥离已知的 Gemini 版本后缀，方便 SDK 自行附加 apiVersion。
     normalized_path = raw_path
     for suffix in _GEMINI_VERSION_SUFFIXES:
         if normalized_path.endswith(suffix):
@@ -74,7 +72,7 @@ def normalize_gemini_base_url(base_url: str) -> str:
 def _parse_absolute_url(value: str):
     """
     EN: Parse a string into a URL and validate that it has an absolute scheme and host.
-    CN: 将字符串解析为 URL，并验证其具有绝对路径的 scheme 和 host。
+    CN: 将字符串解析为 URL，并验证其具备绝对路径所需的 scheme 和 host。
     """
     parsed = urlparse(value.strip())
     if not parsed.scheme or not parsed.netloc:
@@ -93,6 +91,6 @@ def _is_azure_openai_host(host: str) -> bool:
 def _is_public_openai_host(host: str) -> bool:
     """
     EN: Check whether the host is the public OpenAI API endpoint.
-    CN: 检查 host 是否为公网 OpenAI API 端点。
+    CN: 检查 host 是否为公共 OpenAI API 端点。
     """
     return host == "api.openai.com"

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_config.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_config.py
@@ -453,6 +453,21 @@ def test_settings_accepts_canonical_openai_settings(monkeypatch: pytest.MonkeyPa
     assert settings.openai_api_key == "azure-secret"
 
 
+def test_settings_preserve_openrouter_style_openai_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    EN: Verify that custom OpenAI-compatible path prefixes such as OpenRouter /api/v1 are preserved.
+    CN: 验证 OpenRouter 这类带 /api/v1 前缀的 OpenAI 兼容地址会被原样保留。
+    """
+    monkeypatch.setenv("OBJECT_STATE_TABLE", "object-state")
+    monkeypatch.setenv("OPENAI_API_BASE_URL", "https://openrouter.ai/api/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "router-secret")
+
+    settings = Settings.from_env()
+
+    assert settings.openai_api_base_url == "https://openrouter.ai/api/v1/"
+    assert settings.openai_api_key == "router-secret"
+
+
 def test_settings_ignore_legacy_openai_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     EN: Verify that legacy OpenAI alias variables no longer populate the runtime settings.

--- a/services/ocr-pipeline/tests/unit/serverless_mcp/test_provider_urls.py
+++ b/services/ocr-pipeline/tests/unit/serverless_mcp/test_provider_urls.py
@@ -1,0 +1,30 @@
+"""
+EN: Tests for provider URL normalization helpers.
+CN: 提供者 URL 规范化辅助函数的测试。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from serverless_mcp.embed.provider_urls import normalize_openai_base_url
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("https://api.openai.com", "https://api.openai.com/v1/"),
+        ("https://api.openai.com/v1", "https://api.openai.com/v1/"),
+        ("https://example.openai.azure.com", "https://example.openai.azure.com/openai/v1/"),
+        ("https://openrouter.ai/api/v1", "https://openrouter.ai/api/v1/"),
+        ("https://openrouter.ai/api/v1/", "https://openrouter.ai/api/v1/"),
+        ("https://custom.example.com", "https://custom.example.com/v1/"),
+        ("https://custom.example.com/v1", "https://custom.example.com/v1/"),
+    ],
+)
+def test_normalize_openai_base_url_preserves_custom_path_prefix(base_url: str, expected: str) -> None:
+    """
+    EN: Verify OpenAI-compatible normalization preserves explicit path prefixes and canonicalizes known hosts.
+    CN: 验证 OpenAI 兼容归一化会保留显式路径前缀，并规范化已知主机。
+    """
+    assert normalize_openai_base_url(base_url) == expected


### PR DESCRIPTION
Closes #32

## 变更摘要
- 问题是：`OPENAI_API_BASE_URL=https://openrouter.ai/api/v1` 在归一化时被错误改写为 `https://openrouter.ai/v1/`。
- 为什么要改：OpenRouter 这类 OpenAI 兼容端点会因此打到错误路径，embedding 请求返回 HTML，导致 embed Lambda 失败。
- 这次改了什么：`normalize_openai_base_url()` 现在会保留显式路径前缀；补充了 OpenRouter 回归测试，并把部署文档写清楚。
- 没有改什么：没有改 S3、Step Functions、Vector、PaddleOCR 或 embedding 模型协议。
- 对外可见结果：OpenRouter 兼容 embeddings 请求会继续走 `/api/v1`，不再被强制改成 `/v1`。

## 关联 Issue
- 关联 issue：#32
- 关闭关系：本 PR 完整覆盖该 issue。

## 变更类型
- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [x] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [x] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围
- 受影响的目录：`services/ocr-pipeline/src/serverless_mcp/embed/`、`services/ocr-pipeline/src/serverless_mcp/runtime/`、`services/ocr-pipeline/tests/unit/serverless_mcp/`、`docs/`
- 受影响的模块 / 服务：OpenAI 兼容 base URL 归一化、embedding client 构建、运行时配置加载
- 受影响的 workflow：无
- 受影响的数据 / 状态：embed 请求目标 URL
- 是否影响默认 PR 门禁：会影响，因为需要补回归测试并跑全量测试
- 是否影响部署 / 回滚：只影响运行时请求路径，不改部署拓扑

## 详细说明
### 1. 主要改动
- `provider_urls.py` 现在会保留非 Azure、非公共 OpenAI 的显式 path 前缀。
- `test_provider_urls.py` 新增了 OpenAI / Azure OpenAI / OpenRouter / 自定义 host 的归一化回归测试。
- `test_config.py` 新增了 `OPENAI_API_BASE_URL=https://openrouter.ai/api/v1` 的配置回归测试。
- `docs/deployment-config-single-source-of-truth.md` 说明了 OpenRouter 这类自定义前缀不能被重写成 `/v1`。

### 2. 设计选择
- 为什么采用当前方案：改动最小，只修正了错误的路径重写逻辑，同时保留 Azure OpenAI 和公共 OpenAI 的既有行为。
- 备选方案是什么：为 OpenRouter 单独加特判，或者禁止所有非 OpenAI / Azure OpenAI 兼容端点。
- 为什么没有选择备选方案：保留显式路径前缀对所有 OpenAI 兼容服务更通用，也更符合“兼容端点应尊重已配置路径”的原则。

### 3. 兼容性
- 是否向后兼容：是，Azure OpenAI 和 `api.openai.com` 行为保持不变。
- 是否需要迁移：不需要。
- 是否需要重建索引 / 重新部署 / 重新生成产物：不需要，但需要重新部署相关 Lambda。
- 是否引入新环境变量 / 新配置项：不需要。

### 4. 文件清单
- 修改文件：
  - `services/ocr-pipeline/src/serverless_mcp/embed/provider_urls.py`
  - `services/ocr-pipeline/tests/unit/serverless_mcp/test_config.py`
  - `services/ocr-pipeline/tests/unit/serverless_mcp/test_provider_urls.py`
  - `docs/deployment-config-single-source-of-truth.md`
- 新增文件：`services/ocr-pipeline/tests/unit/serverless_mcp/test_provider_urls.py`
- 删除文件：无

## 验证
### 本地验证
- 执行的命令：`uv run --project services pytest`
- 命令输出结论：`315 passed, 2 skipped`
- 相关日志 / 链接：
  - CloudWatch 日志里的失败症状：`OpenAI embedding response is not valid JSON (content-type=text/html; charset=utf-8)`
  - 配置值：`OPENAI_API_BASE_URL=https://openrouter.ai/api/v1`
  - 模型：`OPENAI_EMBEDDING_MODEL=openai/text-embedding-3-small`

### 自动化验证
- [x] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [x] 构建检查
- [x] workflow / CI 检查
- [ ] 其他

### 验证结果
- 通过项：`uv run --project services pytest`、`uv run --project services ruff check`
- 失败项：无
- 未执行项及原因：无

## 风险与回滚
- 主要风险：如果未来还有其他 OpenAI 兼容服务依赖自定义 path 前缀，需要继续沿用“保留显式路径”策略。
- 风险缓解方式：通过单测锁住 OpenRouter 和自定义 host 的归一化行为。
- 回滚方式：回退该提交即可。
- 回滚后遗留影响：OpenRouter 再次被改写成 `/v1`，embedding 请求重新失败。
- 是否需要灰度：建议先在单 profile 或预发环境验证。

## 对业务 / 运维的影响
- 是否影响线上行为：会修复线上 embedding 请求失败。
- 是否影响部署流程：不影响流程，只影响运行时 URL 构造。
- 是否影响监控 / 告警：会减少 embedding 失败告警。
- 是否影响成本 / 性能：无明显影响。
- 是否影响运维手册：已补充配置说明。

## 截图 / 录屏 / 示例
- 截图：无
- 录屏：无
- 示例输入：`OPENAI_API_BASE_URL=https://openrouter.ai/api/v1`
- 示例输出：应请求 `https://openrouter.ai/api/v1/embeddings`

## 待确认事项
- [x] 根因或假设已明确
- [x] 修复方案已明确
- [x] 验证方式已明确
- [x] 回滚或缓解方案已记录

## Reviewer 关注点
- 请重点检查：OpenAI base URL 归一化是否还会误伤其他 OpenAI 兼容端点。
- 请重点验证：OpenRouter 的 `/api/v1` 前缀必须保留。
- 请重点确认：不会影响 Azure OpenAI 和公共 OpenAI 的现有行为。

## 提交前自检
- [x] PR 正文已按模板完整填写
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #32`
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看 GitHub 上实际显示的标题、正文和模板字段