### PR TITLE
[task] 优化 deploy / destroy 的执行速度

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -56,6 +56,13 @@ jobs:
         with:
           setup-node: true
 
+      # EN: Record a shared timing baseline after checkout so later steps can report elapsed phase times.
+      # CN: 在 checkout 之后记录统一的时间基线，便于后续步骤输出分段耗时。
+      - name: Initialize destroy timing baseline
+        run: |
+          set -euo pipefail
+          echo "DESTROY_TIMING_START=$(date +%s)" >> "$GITHUB_ENV"
+
       # EN: Prefer OIDC-based AWS credentials when a role ARN is configured.
       # CN: 当配置了 role ARN 时优先使用基于 OIDC 的 AWS 凭据。
       - name: Configure AWS credentials via OIDC
@@ -90,6 +97,8 @@ jobs:
           set -euo pipefail
           echo "CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_ENV"
           echo "CDK_DEFAULT_REGION=$AWS_REGION" >> "$GITHUB_ENV"
+          now="$(date +%s)"
+          echo "::notice title=Destroy timing::stage=aws-auth+env elapsed=$((now - DESTROY_TIMING_START))s"
 
       # EN: Require the operator to confirm the exact name prefix before any destructive action.
       # CN: 在任何破坏性操作前，都要要求操作者确认精确的 name prefix。
@@ -108,6 +117,8 @@ jobs:
             throw new Error(`name_prefix does not match pipeline-config.json: ${config.name_prefix}`);
           }
           NODE
+          now="$(date +%s)"
+          echo "::notice title=Destroy timing::stage=confirmation-validated elapsed=$((now - DESTROY_TIMING_START))s"
         env:
           INPUT_NAME_PREFIX: ${{ inputs.name_prefix }}
 
@@ -117,6 +128,8 @@ jobs:
         run: |
           set -euo pipefail
           npm ci --prefix infra/cdk --prefer-offline --no-audit --no-fund
+          now="$(date +%s)"
+          echo "::notice title=Destroy timing::stage=cdk-ci elapsed=$((now - DESTROY_TIMING_START))s"
 
       # EN: Destroy the CDK stack directly, using placeholder assets when packaging outputs are not present.
       # CN: 直接销毁 CDK 栈，在没有打包产物时使用占位资源。
@@ -124,3 +137,5 @@ jobs:
         run: |
           set -euo pipefail
           npm --prefix infra/cdk run destroy -- --all --progress events
+          now="$(date +%s)"
+          echo "::notice title=Destroy timing::stage=cdk-destroy elapsed=$((now - DESTROY_TIMING_START))s"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -65,6 +65,13 @@ jobs:
         with:
           setup-node: true
 
+      # EN: Record a shared timing baseline after checkout so later steps can report elapsed phase times.
+      # CN: 在 checkout 之后记录统一的时间基线，便于后续步骤输出分段耗时。
+      - name: Initialize deploy timing baseline
+        run: |
+          set -euo pipefail
+          echo "DEPLOY_TIMING_START=$(date +%s)" >> "$GITHUB_ENV"
+
       # EN: Download the release payload while the CDK dependency tree installs in the background.
       # CN: 在 CDK 依赖安装的同时下载 release 产物，尽量把纯网络等待重叠起来。
       - name: Download packaged release assets and install CDK toolchain
@@ -79,6 +86,8 @@ jobs:
           mkdir -p ./release-assets/layers
           mv ./release-assets/*_layer.zip ./release-assets/layers/ 2>/dev/null || true
           wait "$CDK_CI_PID"
+          now="$(date +%s)"
+          echo "::notice title=Deploy timing::stage=release-download+cdk-ci elapsed=$((now - DEPLOY_TIMING_START))s"
 
       # EN: Prefer OIDC-based AWS credentials when a role ARN is configured.
       # CN: 当配置了 role ARN 时优先使用基于 OIDC 的 AWS 凭据。
@@ -114,6 +123,8 @@ jobs:
           set -euo pipefail
           echo "CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_ENV"
           echo "CDK_DEFAULT_REGION=$AWS_REGION" >> "$GITHUB_ENV"
+          now="$(date +%s)"
+          echo "::notice title=Deploy timing::stage=aws-auth+env elapsed=$((now - DEPLOY_TIMING_START))s"
 
       # EN: Verify the downloaded release manifest matches the requested tag before deploying.
       # CN: 在部署前验证下载到的 release manifest 与请求的 tag 一致。
@@ -129,6 +140,8 @@ jobs:
           }
           console.log(JSON.stringify(report, null, 2));
           NODE
+          now="$(date +%s)"
+          echo "::notice title=Deploy timing::stage=manifest-validated elapsed=$((now - DEPLOY_TIMING_START))s"
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
 
@@ -138,6 +151,8 @@ jobs:
         run: |
           set -euo pipefail
           npm --prefix infra/cdk run deploy -- --all --progress events
+          now="$(date +%s)"
+          echo "::notice title=Deploy timing::stage=cdk-deploy elapsed=$((now - DEPLOY_TIMING_START))s"
 
       - name: Record production deployment summary
         run: |


### PR DESCRIPTION
Closes #38

## 变更摘要
- 缩短 `deploy` / `destroy` 的前置准备时间，重点减少不必要的 checkout 历史下载。
- 在 `prod-deploy` 中把 release 产物下载和 `infra/cdk` 的 `npm ci` 并行执行。
- 在 `destroy` 中把确认校验前置，并将 `npm ci` 调整为离线优先模式。

## 关联 Issue
- Closes #38

## 变更类型
- [x] 维护 / 清理
- [x] CI / workflow
- [x] 性能优化

## 影响范围
- `.github/workflows/prod-deploy.yml`
- `.github/workflows/destroy.yml`

## 详细说明
### 1. 主要改动
- `actions/checkout` 从 `fetch-depth: 0` 改为 `fetch-depth: 1`，避免拉取无用历史。
- `prod-deploy` 将 `gh release download` 与 `npm --prefix infra/cdk ci` 重叠执行，减少串行等待。
- `destroy` 将确认校验保留在安装前，并把 `npm ci` 改成 `--prefer-offline --no-audit --no-fund`。

### 2. 设计选择
- 优先采用低风险 workflow 优化，而不是改动 CDK 业务逻辑。
- 这样能先拿到确定的壁钟时间收益，同时不改变部署语义。

### 3. 兼容性
- 现有部署产物、环境变量和 CDK 入口保持不变。
- 只影响 GitHub Actions 的执行顺序和下载策略。

## 验证
- `uv run --project services python tools/ci/validate_workflows.py`
- `git diff --check`

## 风险与回滚
- 主要风险是并行下载/安装的 shell 步骤日志更集中，但逻辑上仍是独立前置任务。
- 如需回滚，只要撤销这两个 workflow 文件即可。

## 备注
- 这次改动主要压缩的是 workflow 准备阶段；真正的 AWS destroy/deploy 时长仍会受云侧变更量影响。