### PR TITLE
[refactor] 环境感知 bucket 移除策略 + Lambda family bundling

### DIFF
--- a/infra/cdk/lib/config.ts
+++ b/infra/cdk/lib/config.ts
@@ -29,6 +29,8 @@ export interface PipelineDefaults {
   cloudfront_url_ttl_seconds: number;
   api_gateway_stage_name: string;
   fail_on_job_error: boolean;
+  /** EN: Removal policy for data buckets (source/manifest). CN: 数据 bucket（source/manifest）的移除策略。 */
+  data_bucket_removal_policy?: 'RETAIN' | 'DESTROY';
 }
 
 export interface ResourceNames {

--- a/infra/cdk/lib/pipeline/foundation.ts
+++ b/infra/cdk/lib/pipeline/foundation.ts
@@ -33,13 +33,21 @@ export function createPipelineFoundation(scope: Construct, params: PipelineFound
   const defaultSettings = pipelineConfig.defaults;
   const enabledProfiles = pipelineConfig.embedding_profiles.filter((profile) => profile.enabled !== false);
 
+  // EN: Determine bucket removal policy: explicit config wins, otherwise derive from name_prefix.
+  // CN: 确定 bucket 移除策略：显式配置优先，否则从 name_prefix 推导。
+  const rawPolicy = defaultSettings.data_bucket_removal_policy;
+  const isProd = pipelineConfig.name_prefix.includes('-prod') || pipelineConfig.name_prefix.includes('-production');
+  const bucketRemovalPolicy = rawPolicy
+    ? (rawPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY)
+    : (isProd ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY);
+
   const sourceBucket = new s3.Bucket(scope, 'SourceBucket', {
     bucketName: names.source_bucket,
     blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     encryption: s3.BucketEncryption.S3_MANAGED,
     versioned: true,
-    removalPolicy: RemovalPolicy.DESTROY,
-    autoDeleteObjects: true,
+    removalPolicy: bucketRemovalPolicy,
+    autoDeleteObjects: bucketRemovalPolicy === RemovalPolicy.DESTROY,
     lifecycleRules: [
       {
         id: 'expire-noncurrent-source-versions',
@@ -59,18 +67,18 @@ export function createPipelineFoundation(scope: Construct, params: PipelineFound
     blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     encryption: s3.BucketEncryption.S3_MANAGED,
     versioned: true,
-    removalPolicy: RemovalPolicy.DESTROY,
-    autoDeleteObjects: true,
+    removalPolicy: bucketRemovalPolicy,
+    autoDeleteObjects: bucketRemovalPolicy === RemovalPolicy.DESTROY,
   });
 
   const vectorBucket = new s3vectors.CfnVectorBucket(scope, 'VectorBucket', {
     vectorBucketName: names.vector_bucket,
     tags: [{ key: 'app', value: pipelineConfig.repo_name }],
   });
-  vectorBucket.applyRemovalPolicy(RemovalPolicy.DESTROY);
+  vectorBucket.applyRemovalPolicy(bucketRemovalPolicy);
 
   for (const profile of enabledProfiles) {
-    createVectorIndex(scope, profile, vectorBucket, names.vector_bucket);
+    createVectorIndex(scope, profile, vectorBucket, names.vector_bucket, bucketRemovalPolicy);
   }
 
   const ingestQueue = new sqs.Queue(scope, 'IngestQueue', {
@@ -110,18 +118,18 @@ export function createPipelineFoundation(scope: Construct, params: PipelineFound
       indexName: 'lookup-record-type-index',
       partitionKey: { name: 'record_type', type: dynamodb.AttributeType.STRING },
     },
-  ]);
+  ], bucketRemovalPolicy);
   const executionStateTable = createTable(scope, names.execution_state_table, false, [
     { name: 'pk', type: dynamodb.AttributeType.STRING },
-  ]);
+  ], [], bucketRemovalPolicy);
   const manifestIndexTable = createTable(scope, names.manifest_index_table, false, [
     { name: 'pk', type: dynamodb.AttributeType.STRING },
     { name: 'sk', type: dynamodb.AttributeType.STRING },
-  ]);
+  ], [], bucketRemovalPolicy);
   const embeddingProjectionStateTable = createTable(scope, names.embedding_projection_state_table, false, [
     { name: 'pk', type: dynamodb.AttributeType.STRING },
     { name: 'sk', type: dynamodb.AttributeType.STRING },
-  ]);
+  ], [], bucketRemovalPolicy);
 
   return {
     sourceBucket,
@@ -145,6 +153,7 @@ function createTable(
   withGsi: boolean,
   attributes: { name: string; type: dynamodb.AttributeType }[],
   indexes: { indexName: string; partitionKey: { name: string; type: dynamodb.AttributeType } }[] = [],
+  removalPolicy: RemovalPolicy = RemovalPolicy.DESTROY,
 ): dynamodb.Table {
   const table = new dynamodb.Table(scope, pascal(tableName), {
     tableName,
@@ -155,7 +164,7 @@ function createTable(
       pointInTimeRecoveryEnabled: true,
     },
     encryption: dynamodb.TableEncryption.AWS_MANAGED,
-    removalPolicy: RemovalPolicy.DESTROY,
+    removalPolicy,
   });
   if (withGsi) {
     for (const index of indexes) {
@@ -176,6 +185,7 @@ function createVectorIndex(
   profile: EmbeddingProfileConfig,
   vectorBucket: s3vectors.CfnVectorBucket,
   vectorBucketName: string,
+  removalPolicy: RemovalPolicy = RemovalPolicy.DESTROY,
 ): s3vectors.CfnIndex {
   const index = new s3vectors.CfnIndex(scope, `VectorIndex${pascal(profile.profile_id)}`, {
     dataType: 'float32',
@@ -190,6 +200,6 @@ function createVectorIndex(
       : undefined,
   });
   index.addDependency(vectorBucket);
-  index.applyRemovalPolicy(RemovalPolicy.DESTROY);
+  index.applyRemovalPolicy(removalPolicy);
   return index;
 }

--- a/pipeline-config.json
+++ b/pipeline-config.json
@@ -28,7 +28,8 @@
     "query_max_neighbor_expand": 2,
     "cloudfront_url_ttl_seconds": 900,
     "api_gateway_stage_name": "mcp",
-    "fail_on_job_error": true
+    "fail_on_job_error": true,
+    "data_bucket_removal_policy": "RETAIN"
   },
   "resource_names": {
     "source_bucket": "mcp-doc-pipeline-prod-s3-source",

--- a/tools/packaging/serverless_mcp/lambda_wrappers.py
+++ b/tools/packaging/serverless_mcp/lambda_wrappers.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 LAMBDA_HANDLER_MODULES: dict[str, str] = {
     "ingest": "serverless_mcp.entrypoints.ingest",
-    "extract_prepare": "serverless_mcp.entrypoints.extract_prepare",
-    "extract_sync": "serverless_mcp.entrypoints.extract_sync",
-    "extract_submit": "serverless_mcp.entrypoints.extract_submit",
-    "extract_poll": "serverless_mcp.entrypoints.extract_poll",
-    "extract_persist": "serverless_mcp.entrypoints.extract_persist",
-    "extract_mark_failed": "serverless_mcp.entrypoints.extract_mark_failed",
+    "extract_prepare": "serverless_mcp.entrypoints.extract",
+    "extract_sync": "serverless_mcp.entrypoints.extract",
+    "extract_submit": "serverless_mcp.entrypoints.extract",
+    "extract_poll": "serverless_mcp.entrypoints.extract",
+    "extract_persist": "serverless_mcp.entrypoints.extract",
+    "extract_mark_failed": "serverless_mcp.entrypoints.extract",
     "embed": "serverless_mcp.entrypoints.embed",
     "remote_mcp": "serverless_mcp.entrypoints.remote_mcp",
     "backfill": "serverless_mcp.entrypoints.backfill",


### PR DESCRIPTION
## Summary

- 新增 `data_bucket_removal_policy` 配置项，默认 prod 为 RETAIN，dev 为 DESTROY
- 环境感知 bucket 移除策略（source bucket、manifest bucket、DynamoDB 表、vector index）
- 6 个 extract Lambda 共用 1 个 zip（通过 extract.py action router）

## Test plan

- [x] CDK synth 成功
- [x] 271 个单元测试全部通过

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)