### PR TITLE
[task] 拆分部署栈并缩短 deploy / destroy 路径

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -121,4 +121,4 @@ jobs:
       - name: Destroy AWS resources with CDK
         run: |
           set -euo pipefail
-          npm --prefix infra/cdk run destroy -- --all --progress events
+          npm --prefix infra/cdk run destroy

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Deploy production backend
         run: |
           set -euo pipefail
-          npm --prefix infra/cdk run deploy -- --all --progress events
+          npm --prefix infra/cdk run deploy
 
       - name: Record production deployment summary
         run: |

--- a/docs/aws-cdk-deploy-destroy-helpers.md
+++ b/docs/aws-cdk-deploy-destroy-helpers.md
@@ -1,16 +1,17 @@
 # AWS CDK 部署与销毁说明
 
-本文件说明当前 TypeScript CDK 入口的职责分工。部署和销毁都以同一份 `infra/lib/pipeline-stack.ts` 为准，不再依赖旧的 boto3 辅助面作为主入口。
+本文件说明当前 TypeScript CDK 入口的职责分工。部署和销毁都以 `infra/cdk/bin/app.ts` 里拆分后的三个顶层 stack 为准，不再依赖旧的 boto3 辅助面作为主入口。
 
 ## 部署入口
 
 生产发布通过 GitHub Actions 的 `Prod Deploy` 工作流执行，底层命令如下：
 
 ```bash
-npx cdk deploy --all --require-approval never --progress events
+npx cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events
 ```
 
 部署前会先下载 release assets，并将 `MCP_CDK_ASSET_DIR` 指向 `release-assets/`，这样 CDK 栈可以直接消费发布产物。
+当前部署命令优先使用 `--method direct`，因为它比 change set 路径更直接；`--asset-parallelism` 与 `--method direct` 不兼容，所以这里不再同时开启。
 
 ## 销毁入口
 
@@ -39,3 +40,4 @@ npx cdk destroy --all --force --progress events
 - 如果 `cdk synth` 找不到产物，先确认 `MCP_CDK_ASSET_DIR` 是否指向正确目录
 - 如果 `cdk destroy` 失败但不涉及业务资源，先确认是否启用了占位资产模式
 - 如果输入的 `name_prefix` 和配置不一致，工作流会直接失败，避免误删
+- 如果需要调试部署性能，优先观察三个顶层 stack 的顺序和资源 teardown，而不是继续把重点放在 TypeScript 里做 Promise 并行

--- a/docs/aws-cdk-destroy-notes.md
+++ b/docs/aws-cdk-destroy-notes.md
@@ -12,9 +12,10 @@
 ## 销毁行为
 
 - 继续沿用同一份 `pipeline-config.json` 作为资源命名依据
-- 资源删除交给 `cdk destroy --all --force`
+- 资源删除交给 `cdk destroy --all --force --progress events`
 - 当没有真实打包产物时，CDK 栈会使用占位资产完成 synth
 - 销毁只做栈级清理，不再手动维护旧的 boto3 删除顺序
+- 当前入口已拆成 Foundation / Compute / Api 三个顶层 stack，销毁时优先观察数据平面和计算层的删除时长差异
 
 ## 手动执行
 

--- a/docs/deployment-config-single-source-of-truth.md
+++ b/docs/deployment-config-single-source-of-truth.md
@@ -2,8 +2,10 @@
 
 `pipeline-config.json` 仍然是仓库里部署命名和默认值的唯一配置源。它现在被以下位置共同读取：
 
-- `infra/bin/app.ts`
-- `infra/lib/pipeline-stack.ts`
+- `infra/cdk/bin/app.ts`
+- `infra/cdk/lib/foundation-stack.ts`
+- `infra/cdk/lib/compute-stack.ts`
+- `infra/cdk/lib/api-stack.ts`
 - `services/ocr-pipeline/src/serverless_mcp/runtime/config.py`
 - `tools/packaging/serverless_mcp/build_lambda_artifacts.py`
 - `tools/packaging/serverless_mcp/build_layer_artifacts.py`

--- a/docs/workflow-reconcile-notes.md
+++ b/docs/workflow-reconcile-notes.md
@@ -5,14 +5,14 @@
 ## 当前流程
 
 1. `package-release.yml` 在本地集成通过后打包 Lambda 和 Layer zip
-2. `Prod Deploy` 下载 release assets，并执行 `npx cdk deploy --all --require-approval never`
-3. `Destroy` 在需要时执行 `npx cdk destroy --all --force`
+2. `Prod Deploy` 下载 release assets，并执行 `npx cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events`
+3. `Destroy` 在需要时执行 `npx cdk destroy --all --force --progress events`
 4. `Destroy` 会启用占位资产模式，避免在没有 release 产物时无法 synth
 
 ## 对齐原则
 
 - 部署入口统一使用 TypeScript CDK
-- 资源顺序由 CDK 依赖图控制，不再用脚本手工拆阶段
+- 资源顺序由 CDK 依赖图控制，当前 app 由 Foundation / Compute / Api 三个顶层 stack 组成
 - release 产物只负责提供 Lambda 和 Layer 代码，不负责表达基础设施顺序
 - 销毁入口不再依赖 boto3 删除顺序，而是依赖同一份 CDK 定义
 
@@ -20,6 +20,8 @@
 
 - `.github/workflows/prod-deploy.yml`
 - `.github/workflows/destroy.yml`
-- `infra/bin/app.ts`
-- `infra/lib/pipeline-stack.ts`
+- `infra/cdk/bin/app.ts`
+- `infra/cdk/lib/foundation-stack.ts`
+- `infra/cdk/lib/compute-stack.ts`
+- `infra/cdk/lib/api-stack.ts`
 - `docs/README.md`

--- a/infra/cdk/bin/app.ts
+++ b/infra/cdk/bin/app.ts
@@ -1,6 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
+import { ApiStack } from '../lib/api-stack';
+import { ComputeStack } from '../lib/compute-stack';
+import { FoundationStack } from '../lib/foundation-stack';
 import { loadPipelineConfig, resolveDeploymentInputs } from '../lib/config';
-import { PipelineStack } from '../lib/pipeline-stack';
 
 const app = new cdk.App();
 const repoRoot = process.cwd();
@@ -17,15 +19,35 @@ const deploymentInputs = resolveDeploymentInputs(process.env);
 const pipelineConfig = loadPipelineConfig(repoRoot, String(configPath));
 const allowPlaceholderAssets = /^(1|true|yes)$/i.test(process.env.MCP_ALLOW_PLACEHOLDER_ASSETS ?? '');
 
-const stack = new PipelineStack(app, pipelineConfig.name_prefix, {
+const stackPrefix = pipelineConfig.name_prefix;
+const stackEnvironment = {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT ?? process.env.AWS_ACCOUNT_ID,
     region: process.env.CDK_DEFAULT_REGION ?? process.env.AWS_REGION,
   },
+};
+
+const foundationStack = new FoundationStack(app, `${stackPrefix}-foundation`, {
+  ...stackEnvironment,
+  pipelineConfig,
+});
+
+const computeStack = new ComputeStack(app, `${stackPrefix}-compute`, {
+  ...stackEnvironment,
   pipelineConfig,
   artifactDir: String(artifactDir),
   deploymentInputs,
   allowPlaceholderAssets,
 });
 
-cdk.Tags.of(stack).add('app', pipelineConfig.repo_name);
+const apiStack = new ApiStack(app, `${stackPrefix}-api`, {
+  ...stackEnvironment,
+  pipelineConfig,
+});
+
+computeStack.addDependency(foundationStack);
+apiStack.addDependency(computeStack);
+
+cdk.Tags.of(foundationStack).add('app', pipelineConfig.repo_name);
+cdk.Tags.of(computeStack).add('app', pipelineConfig.repo_name);
+cdk.Tags.of(apiStack).add('app', pipelineConfig.repo_name);

--- a/infra/cdk/lib/api-stack.ts
+++ b/infra/cdk/lib/api-stack.ts
@@ -1,0 +1,31 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import type { PipelineConfig } from './config';
+import { buildPipelineResourceBindings } from './pipeline/bindings';
+import { createPipelineApi } from './pipeline/api';
+
+export interface ApiStackProps extends cdk.StackProps {
+  pipelineConfig: PipelineConfig;
+}
+
+// EN: Keep the public REST API in its own stack so endpoint type and gateway lifecycle do not drag the compute layer with them.
+// CN: 将对外 REST API 单独拆成一个栈，避免入口类型和网关生命周期牵连计算层。
+export class ApiStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
+    super(scope, id, props);
+
+    const { pipelineConfig } = props;
+    const bindings = buildPipelineResourceBindings(this, pipelineConfig);
+    const api = createPipelineApi({
+      stack: this,
+      pipelineConfig,
+      bindings,
+    });
+
+    new cdk.CfnOutput(this, 'RemoteMcpApiUrl', {
+      value: api.remoteMcpApi.url ?? '',
+    });
+
+    cdk.Tags.of(this).add('app', pipelineConfig.repo_name);
+  }
+}

--- a/infra/cdk/lib/compute-stack.ts
+++ b/infra/cdk/lib/compute-stack.ts
@@ -1,0 +1,40 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import type { DeploymentInputs, PipelineConfig } from './config';
+import { buildPipelineResourceBindings } from './pipeline/bindings';
+import { createPipelineCompute } from './pipeline/compute';
+
+export interface ComputeStackProps extends cdk.StackProps {
+  pipelineConfig: PipelineConfig;
+  artifactDir: string;
+  deploymentInputs: DeploymentInputs;
+  allowPlaceholderAssets?: boolean;
+}
+
+// EN: Keep Lambda, Step Functions, and execution roles in a separate compute stack so their assets can evolve independently.
+// CN: 将 Lambda、Step Functions 和执行角色放入独立的计算栈，方便它们独立演进。
+export class ComputeStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: ComputeStackProps) {
+    super(scope, id, props);
+
+    const { pipelineConfig, artifactDir, deploymentInputs, allowPlaceholderAssets = false } = props;
+    const bindings = buildPipelineResourceBindings(this, pipelineConfig);
+    const compute = createPipelineCompute({
+      stack: this,
+      pipelineConfig,
+      artifactDir,
+      deploymentInputs,
+      allowPlaceholderAssets,
+      bindings,
+    });
+
+    new cdk.CfnOutput(this, 'StateMachineArn', {
+      value: compute.stateMachine.stateMachineArn,
+    });
+    new cdk.CfnOutput(this, 'RemoteMcpLambdaArn', {
+      value: compute.remoteMcpLambda.functionArn,
+    });
+
+    cdk.Tags.of(this).add('app', pipelineConfig.repo_name);
+  }
+}

--- a/infra/cdk/lib/foundation-stack.ts
+++ b/infra/cdk/lib/foundation-stack.ts
@@ -1,0 +1,42 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import type { PipelineConfig } from './config';
+import { buildPipelineResourceBindings } from './pipeline/bindings';
+import { createPipelineFoundation } from './pipeline/foundation';
+
+export interface FoundationStackProps extends cdk.StackProps {
+  pipelineConfig: PipelineConfig;
+}
+
+// EN: Keep the shared data plane in a dedicated top-level stack so destroy can tear it down separately from compute.
+// CN: 将共享数据平面放入独立的顶层 stack，方便销毁时与计算层分开处理。
+export class FoundationStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: FoundationStackProps) {
+    super(scope, id, props);
+
+    const { pipelineConfig } = props;
+    const names = pipelineConfig.resource_names;
+    const bindings = buildPipelineResourceBindings(this, pipelineConfig);
+    const foundation = createPipelineFoundation(this, {
+      pipelineConfig,
+    });
+
+    new cdk.CfnOutput(this, 'SourceBucketName', {
+      value: foundation.sourceBucket.bucketName,
+    });
+    new cdk.CfnOutput(this, 'ManifestBucketName', {
+      value: foundation.manifestBucket.bucketName,
+    });
+    new cdk.CfnOutput(this, 'VectorBucketName', {
+      value: names.vector_bucket,
+    });
+    new cdk.CfnOutput(this, 'IngestQueueArn', {
+      value: bindings.ingestQueueArn,
+    });
+    new cdk.CfnOutput(this, 'EmbedQueueArn', {
+      value: bindings.embedQueueArn,
+    });
+
+    cdk.Tags.of(this).add('app', pipelineConfig.repo_name);
+  }
+}

--- a/infra/cdk/lib/pipeline-stack.ts
+++ b/infra/cdk/lib/pipeline-stack.ts
@@ -1,9 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { ApiStack } from './api-stack';
+import { ComputeStack } from './compute-stack';
+import { FoundationStack } from './foundation-stack';
 import type { DeploymentInputs, PipelineConfig } from './config';
-import { createPipelineCompute } from './pipeline/compute';
-import { createPipelineFoundation } from './pipeline/foundation';
-import { createPipelineRoles } from './pipeline/roles';
 
 export interface PipelineStackProps extends cdk.StackProps {
   pipelineConfig: PipelineConfig;
@@ -12,61 +12,38 @@ export interface PipelineStackProps extends cdk.StackProps {
   allowPlaceholderAssets?: boolean;
 }
 
+// EN: Keep a compatibility wrapper for the historical single-stack entry while the app now instantiates the split stacks directly.
+// CN: 保留历史单栈入口的兼容包装，但实际 app 已经直接实例化拆分后的多个 stack。
 export class PipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PipelineStackProps) {
     super(scope, id, props);
 
     const { pipelineConfig, artifactDir, deploymentInputs, allowPlaceholderAssets = false } = props;
-    const names = pipelineConfig.resource_names;
+    const stackEnvironment = {
+      env: {
+        account: props.env?.account ?? process.env.CDK_DEFAULT_ACCOUNT ?? process.env.AWS_ACCOUNT_ID,
+        region: props.env?.region ?? process.env.CDK_DEFAULT_REGION ?? process.env.AWS_REGION,
+      },
+    };
 
-    // EN: Build shared buckets, tables, queues, and vector indexes first so later compute resources can reuse them.
-    // CN: 先构建共享的 bucket、table、queue 和 vector index，让后续计算资源直接复用。
-    const foundation = createPipelineFoundation(this, {
+    const foundationStack = new FoundationStack(scope, `${id}-foundation`, {
+      ...stackEnvironment,
       pipelineConfig,
     });
-
-    // EN: Bind least-privilege execution roles to the already created shared resources.
-    // CN: 把最小权限的执行角色绑定到已经创建好的共享资源上。
-    const roles = createPipelineRoles({
-      stack: this,
-      names: pipelineConfig.resource_names,
-      pipelineConfig,
-      sourceBucket: foundation.sourceBucket,
-      manifestBucket: foundation.manifestBucket,
-      embedQueue: foundation.embedQueue,
-      ingestQueue: foundation.ingestQueue,
-      objectStateTable: foundation.objectStateTable,
-      executionStateTable: foundation.executionStateTable,
-      manifestIndexTable: foundation.manifestIndexTable,
-      embeddingProjectionStateTable: foundation.embeddingProjectionStateTable,
-    });
-
-    // EN: Layer Lambda, state machine, and API resources on top of the shared foundation.
-    // CN: 在共享基础设施之上叠加 Lambda、状态机和 API 资源。
-    const compute = createPipelineCompute({
-      stack: this,
+    const computeStack = new ComputeStack(scope, `${id}-compute`, {
+      ...stackEnvironment,
       pipelineConfig,
       artifactDir,
       deploymentInputs,
       allowPlaceholderAssets,
-      foundation,
-      roles,
+    });
+    const apiStack = new ApiStack(scope, `${id}-api`, {
+      ...stackEnvironment,
+      pipelineConfig,
     });
 
-    // EN: Publish only the outputs that deployment and smoke-test workflows actually consume.
-    // CN: 只公开部署和冒烟测试工作流真正会消费的输出。
-    new cdk.CfnOutput(this, 'RemoteMcpApiUrl', {
-      value: compute.remoteMcpApi.url ?? '',
-    });
-    new cdk.CfnOutput(this, 'StateMachineArn', {
-      value: compute.stateMachine.stateMachineArn,
-    });
-    new cdk.CfnOutput(this, 'VectorBucketName', {
-      value: names.vector_bucket,
-    });
-    new cdk.CfnOutput(this, 'SourceBucketName', {
-      value: foundation.sourceBucket.bucketName,
-    });
+    computeStack.addDependency(foundationStack);
+    apiStack.addDependency(computeStack);
 
     cdk.Tags.of(this).add('app', pipelineConfig.repo_name);
   }

--- a/infra/cdk/lib/pipeline/api.ts
+++ b/infra/cdk/lib/pipeline/api.ts
@@ -1,0 +1,46 @@
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import type { Construct } from 'constructs';
+import type { PipelineConfig } from '../config';
+import type { PipelineResourceBindings } from './bindings';
+
+export interface PipelineApiResources {
+  remoteMcpApi: apigateway.RestApi;
+  remoteMcpLambda: lambda.IFunction;
+}
+
+export interface PipelineApiParams {
+  stack: Construct;
+  pipelineConfig: PipelineConfig;
+  bindings: PipelineResourceBindings;
+}
+
+// EN: Keep the REST API isolated so the edge-to-regional choice and the invoke surface can evolve independently.
+// CN: 将 REST API 独立出来，方便 API 入口类型和调用面单独演进。
+export function createPipelineApi(params: PipelineApiParams): PipelineApiResources {
+  const { stack, pipelineConfig, bindings } = params;
+  const names = pipelineConfig.resource_names;
+  const remoteMcpLambda = lambda.Function.fromFunctionAttributes(stack, 'RemoteMcpLambda', {
+    functionArn: bindings.remoteMcpLambdaArn,
+    sameEnvironment: true,
+  });
+
+  const remoteMcpApi = new apigateway.RestApi(stack, 'RemoteMcpApi', {
+    restApiName: names.remote_mcp_api_gateway,
+    description: `Remote MCP REST API for ${pipelineConfig.repo_name}`,
+    endpointTypes: [apigateway.EndpointType.REGIONAL],
+    deployOptions: {
+      stageName: pipelineConfig.defaults.api_gateway_stage_name,
+    },
+  });
+  const remoteMcpIntegration = new apigateway.LambdaIntegration(remoteMcpLambda, {
+    proxy: true,
+  });
+  remoteMcpApi.root.addMethod('ANY', remoteMcpIntegration);
+  remoteMcpApi.root.addResource('{proxy+}').addMethod('ANY', remoteMcpIntegration);
+
+  return {
+    remoteMcpApi,
+    remoteMcpLambda,
+  };
+}

--- a/infra/cdk/lib/pipeline/bindings.ts
+++ b/infra/cdk/lib/pipeline/bindings.ts
@@ -1,0 +1,53 @@
+import * as cdk from 'aws-cdk-lib';
+import type { PipelineConfig } from '../config';
+
+export interface PipelineResourceBindings {
+  sourceBucketArn: string;
+  sourceBucketObjectArn: string;
+  manifestBucketArn: string;
+  manifestBucketObjectArn: string;
+  vectorBucketArn: string;
+  vectorIndexArns: string[];
+  ingestQueueArn: string;
+  ingestQueueUrl: string;
+  embedQueueArn: string;
+  embedQueueUrl: string;
+  objectStateTableArn: string;
+  executionStateTableArn: string;
+  manifestIndexTableArn: string;
+  embeddingProjectionStateTableArn: string;
+  stateMachineArn: string;
+  ingestLambdaArn: string;
+  embedLambdaArn: string;
+  remoteMcpLambdaArn: string;
+}
+
+export function buildPipelineResourceBindings(scope: cdk.Stack, pipelineConfig: PipelineConfig): PipelineResourceBindings {
+  const { resource_names: names, embedding_profiles } = pipelineConfig;
+  const region = scope.region;
+  const account = scope.account;
+  const enabledProfiles = embedding_profiles.filter((profile) => profile.enabled !== false);
+
+  return {
+    sourceBucketArn: `arn:aws:s3:::${names.source_bucket}`,
+    sourceBucketObjectArn: `arn:aws:s3:::${names.source_bucket}/*`,
+    manifestBucketArn: `arn:aws:s3:::${names.manifest_bucket}`,
+    manifestBucketObjectArn: `arn:aws:s3:::${names.manifest_bucket}/*`,
+    vectorBucketArn: `arn:aws:s3vectors:${region}:${account}:bucket/${names.vector_bucket}`,
+    vectorIndexArns: enabledProfiles.map(
+      (profile) => `arn:aws:s3vectors:${region}:${account}:bucket/${profile.vector_bucket_name}/index/${profile.vector_index_name}`,
+    ),
+    ingestQueueArn: `arn:aws:sqs:${region}:${account}:${names.ingest_queue}`,
+    ingestQueueUrl: `https://sqs.${region}.amazonaws.com/${account}/${names.ingest_queue}`,
+    embedQueueArn: `arn:aws:sqs:${region}:${account}:${names.embed_queue}`,
+    embedQueueUrl: `https://sqs.${region}.amazonaws.com/${account}/${names.embed_queue}`,
+    objectStateTableArn: `arn:aws:dynamodb:${region}:${account}:table/${names.object_state_table}`,
+    executionStateTableArn: `arn:aws:dynamodb:${region}:${account}:table/${names.execution_state_table}`,
+    manifestIndexTableArn: `arn:aws:dynamodb:${region}:${account}:table/${names.manifest_index_table}`,
+    embeddingProjectionStateTableArn: `arn:aws:dynamodb:${region}:${account}:table/${names.embedding_projection_state_table}`,
+    stateMachineArn: `arn:aws:states:${region}:${account}:stateMachine:${names.state_machine}`,
+    ingestLambdaArn: `arn:aws:lambda:${region}:${account}:function:${names.ingest_lambda}`,
+    embedLambdaArn: `arn:aws:lambda:${region}:${account}:function:${names.embed_lambda}`,
+    remoteMcpLambdaArn: `arn:aws:lambda:${region}:${account}:function:${names.remote_mcp_lambda}`,
+  };
+}

--- a/infra/cdk/lib/pipeline/compute.ts
+++ b/infra/cdk/lib/pipeline/compute.ts
@@ -1,6 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
-import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
@@ -9,8 +8,8 @@ import type { Construct } from 'constructs';
 import { buildLayerZipPath, buildLambdaZipPath, LAYER_KEYS, type LayerKey, type LambdaFunctionKey } from '../artifacts';
 import type { DeploymentInputs, PipelineConfig } from '../config';
 import { defaultRuntimeSettings, pascal, renderStateMachineDefinition, resolveAssetPath } from './helpers';
-import { type LambdaRoleBundle, type LambdaRoleKey } from './roles';
-import type { PipelineFoundationResources } from './foundation';
+import { createPipelineRoles, type LambdaRoleBundle, type LambdaRoleKey } from './roles';
+import type { PipelineResourceBindings } from './bindings';
 
 export interface LambdaDefinition {
   functionKey: LambdaFunctionKey;
@@ -22,7 +21,7 @@ export interface LambdaDefinition {
 export interface PipelineComputeResources {
   lambdaFunctions: Map<LambdaFunctionKey, lambda.Function>;
   stateMachine: sfn.StateMachine;
-  remoteMcpApi: apigateway.RestApi;
+  remoteMcpLambda: lambda.Function;
 }
 
 export interface PipelineComputeParams {
@@ -31,18 +30,22 @@ export interface PipelineComputeParams {
   artifactDir: string;
   deploymentInputs: DeploymentInputs;
   allowPlaceholderAssets: boolean;
-  foundation: PipelineFoundationResources;
-  roles: LambdaRoleBundle;
+  bindings: PipelineResourceBindings;
 }
 
 // EN: Build the Lambda, state machine, and API layer separately from the shared data-plane foundation.
 // CN: 将 Lambda、状态机和 API 层与共享数据平面基础设施分开构建。
 export function createPipelineCompute(params: PipelineComputeParams): PipelineComputeResources {
-  const { stack, pipelineConfig, artifactDir, deploymentInputs, allowPlaceholderAssets, foundation, roles } = params;
+  const { stack, pipelineConfig, artifactDir, deploymentInputs, allowPlaceholderAssets, bindings } = params;
   const names = pipelineConfig.resource_names;
   const defaultSettings = pipelineConfig.defaults;
   const runtime = new lambda.Runtime(defaultSettings.runtime, lambda.RuntimeFamily.PYTHON);
   const architecture = defaultSettings.architecture === 'x86_64' ? lambda.Architecture.X86_64 : lambda.Architecture.ARM_64;
+  const roles = createPipelineRoles({
+    stack,
+    names,
+    bindings,
+  });
 
   // EN: Stage layer assets first so every Lambda can reuse the same layer map and placeholder logic.
   // CN: 先准备 layer 产物，确保每个 Lambda 都复用同一份 layer 映射和占位逻辑。
@@ -73,11 +76,10 @@ export function createPipelineCompute(params: PipelineComputeParams): PipelineCo
       memorySize: runtimeSettings.memory_size,
       timeout: Duration.seconds(runtimeSettings.timeout_seconds),
       environment: buildLambdaEnvironment({
-        stack,
         pipelineConfig,
         deploymentInputs,
         names,
-        embedQueue: foundation.embedQueue,
+        bindings,
         defaultSettings,
         functionKey: definition.functionKey,
         allowPlaceholderAssets,
@@ -92,13 +94,13 @@ export function createPipelineCompute(params: PipelineComputeParams): PipelineCo
   // EN: Ingest and embed are queue consumers; keep the event-source mappings explicit instead of hiding them in the definition array.
   // CN: Ingest 和 embed 是队列消费者；保持 event source mapping 显式可见，不把它藏进定义数组里。
   lambdaFunctions.get('ingest')?.addEventSourceMapping('IngestQueueMapping', {
-    eventSourceArn: foundation.ingestQueue.queueArn,
+    eventSourceArn: bindings.ingestQueueArn,
     batchSize: 10,
     enabled: true,
     reportBatchItemFailures: true,
   });
   lambdaFunctions.get('embed')?.addEventSourceMapping('EmbedQueueMapping', {
-    eventSourceArn: foundation.embedQueue.queueArn,
+    eventSourceArn: bindings.embedQueueArn,
     batchSize: 1,
     enabled: true,
     reportBatchItemFailures: true,
@@ -125,22 +127,6 @@ export function createPipelineCompute(params: PipelineComputeParams): PipelineCo
     tracingEnabled: true,
   });
   stateMachine.applyRemovalPolicy(RemovalPolicy.DESTROY);
-
-  // EN: Expose the remote MCP surface as a small, explicit API wrapper around the Lambda handler.
-  // CN: 将远程 MCP 面封装成一个小而明确的 API 包装层，直连 Lambda 处理器。
-  const remoteMcpApi = new apigateway.RestApi(stack, 'RemoteMcpApi', {
-    restApiName: names.remote_mcp_api_gateway,
-    description: `Remote MCP REST API for ${pipelineConfig.repo_name}`,
-    endpointTypes: [apigateway.EndpointType.EDGE],
-    deployOptions: {
-      stageName: defaultSettings.api_gateway_stage_name,
-    },
-  });
-  const remoteMcpIntegration = new apigateway.LambdaIntegration(lambdaFunctions.get('remote_mcp')!, {
-    proxy: true,
-  });
-  remoteMcpApi.root.addMethod('ANY', remoteMcpIntegration);
-  remoteMcpApi.root.addResource('{proxy+}').addMethod('ANY', remoteMcpIntegration);
 
   // EN: Grant the state machine only the invoke/logging permissions it needs for extract orchestration.
   // CN: 只给状态机授予 extract 编排所需的 invoke 和日志权限。
@@ -186,7 +172,7 @@ export function createPipelineCompute(params: PipelineComputeParams): PipelineCo
   return {
     lambdaFunctions,
     stateMachine,
-    remoteMcpApi,
+    remoteMcpLambda: lambdaFunctions.get('remote_mcp')!,
   };
 }
 
@@ -211,16 +197,15 @@ function createLambdaDefinitions(names: PipelineConfig['resource_names']): Lambd
 // EN: Build Lambda environment variables in one place so the deployment and runtime contract stays visible.
 // CN: 把 Lambda 环境变量集中在一处构建，方便同时看清部署和运行时契约。
 function buildLambdaEnvironment(params: {
-  stack: cdk.Stack;
   pipelineConfig: PipelineConfig;
   deploymentInputs: DeploymentInputs;
   names: PipelineConfig['resource_names'];
-  embedQueue: PipelineFoundationResources['embedQueue'];
+  bindings: PipelineResourceBindings;
   defaultSettings: PipelineConfig['defaults'];
   functionKey: LambdaFunctionKey;
   allowPlaceholderAssets: boolean;
 }): Record<string, string> {
-  const { stack, pipelineConfig, deploymentInputs, names, embedQueue, defaultSettings, functionKey, allowPlaceholderAssets } = params;
+  const { pipelineConfig, deploymentInputs, names, bindings, defaultSettings, functionKey, allowPlaceholderAssets } = params;
   const env: Record<string, string> = {
     POWERTOOLS_SERVICE_NAME: pipelineConfig.repo_name,
     OBJECT_STATE_TABLE: names.object_state_table,
@@ -281,7 +266,7 @@ function buildLambdaEnvironment(params: {
   }
 
   if (functionKey === 'ingest') {
-    env.STEP_FUNCTIONS_STATE_MACHINE_ARN = `arn:aws:states:${stack.region}:${stack.account}:stateMachine:${names.state_machine}`;
+    env.STEP_FUNCTIONS_STATE_MACHINE_ARN = bindings.stateMachineArn;
   }
   if (functionKey === 'remote_mcp' && deploymentInputs.remoteMcpDefaultTenantId) {
     env.REMOTE_MCP_DEFAULT_TENANT_ID = deploymentInputs.remoteMcpDefaultTenantId;
@@ -302,7 +287,7 @@ function buildLambdaEnvironment(params: {
     env.FAIL_ON_JOB_ERROR = String(defaultSettings.fail_on_job_error);
   }
   if (functionKey === 'extract_persist' || functionKey === 'backfill') {
-    env.EMBED_QUEUE_URL = embedQueue.queueUrl;
+    env.EMBED_QUEUE_URL = bindings.embedQueueUrl;
   }
   return env;
 }

--- a/infra/cdk/lib/pipeline/roles.ts
+++ b/infra/cdk/lib/pipeline/roles.ts
@@ -1,10 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
-import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as sqs from 'aws-cdk-lib/aws-sqs';
 import type { PipelineConfig } from '../config';
 import { pascal } from './helpers';
+import type { PipelineResourceBindings } from './bindings';
 
 export type LambdaRoleKey = 'query' | 'status' | 'backfill' | 'ingest' | 'extract' | 'embed';
 
@@ -16,15 +14,7 @@ export interface LambdaRoleBundle {
 export interface PipelineRoleParams {
   stack: cdk.Stack;
   names: PipelineConfig['resource_names'];
-  pipelineConfig: PipelineConfig;
-  sourceBucket: s3.Bucket;
-  manifestBucket: s3.Bucket;
-  embedQueue: sqs.Queue;
-  ingestQueue: sqs.Queue;
-  objectStateTable: dynamodb.Table;
-  executionStateTable: dynamodb.Table;
-  manifestIndexTable: dynamodb.Table;
-  embeddingProjectionStateTable: dynamodb.Table;
+  bindings: PipelineResourceBindings;
 }
 
 const LAMBDA_ROLE_KEYS: LambdaRoleKey[] = ['query', 'status', 'backfill', 'ingest', 'extract', 'embed'];
@@ -64,33 +54,30 @@ function attachLambdaDataPlanePolicy(
   roleKey: LambdaRoleKey,
   params: PipelineRoleParams,
 ): void {
-  const profiles = params.pipelineConfig.embedding_profiles.filter((profile) => profile.enabled !== false);
-  const vectorResources = profiles.map(
-    (profile) => `arn:aws:s3vectors:${params.stack.region}:${params.stack.account}:bucket/${profile.vector_bucket_name}/index/${profile.vector_index_name}`,
-  );
+  const vectorResources = params.bindings.vectorIndexArns;
   const statements: iam.PolicyStatement[] = [];
 
   if (roleKey === 'query') {
     statements.push(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
-        resources: [params.objectStateTable.tableArn],
+        resources: [params.bindings.objectStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
-        resources: [params.executionStateTable.tableArn],
+        resources: [params.bindings.executionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.manifestIndexTable.tableArn],
+        resources: [params.bindings.manifestIndexTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.embeddingProjectionStateTable.tableArn],
+        resources: [params.bindings.embeddingProjectionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion'],
-        resources: [params.manifestBucket.arnForObjects('*')],
+        resources: [params.bindings.manifestBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3vectors:QueryVectors', 's3vectors:GetVectors'],
@@ -101,77 +88,77 @@ function attachLambdaDataPlanePolicy(
     statements.push(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
-        resources: [params.objectStateTable.tableArn],
+        resources: [params.bindings.objectStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
-        resources: [params.executionStateTable.tableArn],
+        resources: [params.bindings.executionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.manifestIndexTable.tableArn],
+        resources: [params.bindings.manifestIndexTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.embeddingProjectionStateTable.tableArn],
+        resources: [params.bindings.embeddingProjectionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion'],
-        resources: [params.manifestBucket.arnForObjects('*')],
+        resources: [params.bindings.manifestBucketObjectArn],
       }),
     );
   } else if (roleKey === 'backfill') {
     statements.push(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:Scan', 'dynamodb:DescribeTable'],
-        resources: [params.objectStateTable.tableArn],
+        resources: [params.bindings.objectStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
-        resources: [params.executionStateTable.tableArn],
+        resources: [params.bindings.executionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.manifestIndexTable.tableArn],
+        resources: [params.bindings.manifestIndexTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.embeddingProjectionStateTable.tableArn],
+        resources: [params.bindings.embeddingProjectionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion'],
-        resources: [params.manifestBucket.arnForObjects('*')],
+        resources: [params.bindings.manifestBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['sqs:SendMessage'],
-        resources: [params.embedQueue.queueArn],
+        resources: [params.bindings.embedQueueArn],
       }),
     );
   } else if (roleKey === 'ingest') {
     statements.push(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:TransactWriteItems', 'dynamodb:UpdateItem', 'dynamodb:DescribeTable'],
-        resources: [params.objectStateTable.tableArn],
+        resources: [params.bindings.objectStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
-        resources: [params.executionStateTable.tableArn],
+        resources: [params.bindings.executionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.manifestIndexTable.tableArn],
+        resources: [params.bindings.manifestIndexTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:PutItem', 'dynamodb:DescribeTable'],
-        resources: [params.embeddingProjectionStateTable.tableArn],
+        resources: [params.bindings.embeddingProjectionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging', 's3:GetObjectVersionTagging'],
-        resources: [params.sourceBucket.arnForObjects('*')],
+        resources: [params.bindings.sourceBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion'],
-        resources: [params.manifestBucket.arnForObjects('*')],
+        resources: [params.bindings.manifestBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3vectors:GetVectors', 's3vectors:PutVectors'],
@@ -179,61 +166,61 @@ function attachLambdaDataPlanePolicy(
       }),
       new iam.PolicyStatement({
         actions: ['sqs:ReceiveMessage', 'sqs:DeleteMessage', 'sqs:GetQueueAttributes', 'sqs:ChangeMessageVisibility'],
-        resources: [params.ingestQueue.queueArn],
+        resources: [params.bindings.ingestQueueArn],
       }),
       new iam.PolicyStatement({
         actions: ['states:StartExecution'],
-        resources: [`arn:aws:states:${params.stack.region}:${params.stack.account}:stateMachine:${params.names.state_machine}`],
+        resources: [params.bindings.stateMachineArn],
       }),
     );
   } else if (roleKey === 'extract') {
     statements.push(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:Query', 'dynamodb:TransactWriteItems', 'dynamodb:UpdateItem', 'dynamodb:DescribeTable'],
-        resources: [params.objectStateTable.tableArn],
+        resources: [params.bindings.objectStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:DescribeTable'],
-        resources: [params.executionStateTable.tableArn],
+        resources: [params.bindings.executionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.manifestIndexTable.tableArn],
+        resources: [params.bindings.manifestIndexTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging', 's3:GetObjectVersionTagging'],
-        resources: [params.sourceBucket.arnForObjects('*')],
+        resources: [params.bindings.sourceBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion', 's3:PutObject', 's3:DeleteObject'],
-        resources: [params.manifestBucket.arnForObjects('*')],
+        resources: [params.bindings.manifestBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['sqs:SendMessage'],
-        resources: [params.embedQueue.queueArn],
+        resources: [params.bindings.embedQueueArn],
       }),
     );
   } else if (roleKey === 'embed') {
     statements.push(
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:Query', 'dynamodb:TransactWriteItems', 'dynamodb:UpdateItem', 'dynamodb:DescribeTable'],
-        resources: [params.objectStateTable.tableArn],
+        resources: [params.bindings.objectStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:DescribeTable'],
-        resources: [params.executionStateTable.tableArn],
+        resources: [params.bindings.executionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.manifestIndexTable.tableArn],
+        resources: [params.bindings.manifestIndexTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['dynamodb:BatchWriteItem', 'dynamodb:DeleteItem', 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:DescribeTable'],
-        resources: [params.embeddingProjectionStateTable.tableArn],
+        resources: [params.bindings.embeddingProjectionStateTableArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:GetObjectVersion', 's3:DeleteObject'],
-        resources: [params.manifestBucket.arnForObjects('*')],
+        resources: [params.bindings.manifestBucketObjectArn],
       }),
       new iam.PolicyStatement({
         actions: ['s3vectors:GetVectors', 's3vectors:PutVectors', 's3vectors:DeleteVectors'],
@@ -241,7 +228,7 @@ function attachLambdaDataPlanePolicy(
       }),
       new iam.PolicyStatement({
         actions: ['sqs:ReceiveMessage', 'sqs:DeleteMessage', 'sqs:GetQueueAttributes', 'sqs:ChangeMessageVisibility'],
-        resources: [params.embedQueue.queueArn],
+        resources: [params.bindings.embedQueueArn],
       }),
     );
   }

--- a/infra/cdk/package.json
+++ b/infra/cdk/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "synth": "cd ../.. && npm --prefix infra/cdk exec -- cdk synth",
     "diff": "cd ../.. && npm --prefix infra/cdk exec -- cdk diff",
-    "deploy": "cd ../.. && npm --prefix infra/cdk exec -- cdk deploy --require-approval never",
-    "destroy": "cd ../.. && npm --prefix infra/cdk exec -- cdk destroy --force"
+    "deploy": "cd ../.. && npm --prefix infra/cdk exec -- cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events",
+    "destroy": "cd ../.. && npm --prefix infra/cdk exec -- cdk destroy --all --force --progress events"
   },
   "dependencies": {
     "aws-cdk": "^2.1113.0",

--- a/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -19,7 +19,7 @@ def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     assert "npm ci --prefix infra/cdk" in workflow_text
     assert "aws sts get-caller-identity" in workflow_text
     assert "Validate release asset manifest" in workflow_text
-    assert "npm --prefix infra/cdk run deploy -- --all --progress events" in workflow_text
+    assert "npm --prefix infra/cdk run deploy" in workflow_text
     assert "Record production deployment summary" in workflow_text
     assert workflow_text.index("Validate release tag confirmation") < workflow_text.index("Deploy production backend")
 
@@ -36,5 +36,26 @@ def test_destroy_workflow_uses_cdk_destroy_with_placeholder_assets() -> None:
     assert "npm ci --prefix infra/cdk" in workflow_text
     assert "aws sts get-caller-identity" in workflow_text
     assert "Validate destroy confirmation" in workflow_text
-    assert "npm --prefix infra/cdk run destroy -- --all --progress events" in workflow_text
+    assert "npm --prefix infra/cdk run destroy" in workflow_text
     assert "confirm_destroy does not match name_prefix" in workflow_text
+
+
+def test_cdk_package_scripts_use_split_stack_speedup_flags() -> None:
+    package_path = Path(__file__).resolve().parents[4] / "infra" / "cdk" / "package.json"
+    package_text = package_path.read_text(encoding="utf-8")
+
+    assert '"deploy": "cd ../.. && npm --prefix infra/cdk exec -- cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events"' in package_text
+    assert '"destroy": "cd ../.. && npm --prefix infra/cdk exec -- cdk destroy --all --force --progress events"' in package_text
+
+
+def test_cdk_app_instantiates_three_top_level_stacks_and_regional_api() -> None:
+    app_path = Path(__file__).resolve().parents[4] / "infra" / "cdk" / "bin" / "app.ts"
+    api_path = Path(__file__).resolve().parents[4] / "infra" / "cdk" / "lib" / "pipeline" / "api.ts"
+    app_text = app_path.read_text(encoding="utf-8")
+    api_text = api_path.read_text(encoding="utf-8")
+
+    assert "new FoundationStack(" in app_text
+    assert "new ComputeStack(" in app_text
+    assert "new ApiStack(" in app_text
+    assert "EndpointType.REGIONAL" in api_text
+    assert "EndpointType.EDGE" not in api_text


### PR DESCRIPTION
Closes #42

## 变更摘要

- 问题是什么：当前 CDK 入口仍然是单个 `PipelineStack`，deploy / destroy 的耗时主要来自单栈资源体量和销毁路径，而不是 TypeScript 里能否再做 Promise 并行。
- 为什么要改：把基础设施、计算层和公共 API 拆成三个顶层 stack 后，资源边界更清晰，销毁时可以分层处理；同时把 API Gateway 改成 `REGIONAL`，减少边缘型入口带来的额外复杂度。
- 这次改了什么：新增 `FoundationStack` / `ComputeStack` / `ApiStack`，把 API 入口和 Lambda 解耦，部署脚本改成 `cdk deploy --all --method direct --concurrency 3`，destroy 脚本继续保持 `--all --force`，并同步更新相关文档与回归测试。
- 没有改什么：没有继续把重点放在 CDK 内部异步写法，也没有改业务处理链路、OCR / embedding 契约或向量检索逻辑。
- 对外可见的结果：部署和销毁说明现在指向三个顶层 stack；`Prod Deploy` / `Destroy` workflow 直接调用新的 npm 脚本，API Gateway 入口改为区域型。

## 关联 Issue

- 关联 issue：`#42`
- 关闭关系：Closes #42
- 如果是跨仓库引用，请写明完整链接：不适用
- 如果没有关联 issue，请说明原因：不适用

## 变更类型

请选择所有适用项：

- [ ] 缺陷修复
- [ ] 新功能
- [x] 重构
- [x] 文档
- [ ] 安全加固
- [x] CI / workflow
- [x] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围

说明这次改动会影响哪些层、模块、流程或外部接口。

- 受影响的目录：`infra/cdk/`、`.github/workflows/`、`docs/`、`tools/ci/tests/`
- 受影响的模块 / 服务：CDK app 入口、基础设施 stack、API Gateway 入口、部署脚本
- 受影响的 workflow：`prod-deploy.yml`、`destroy.yml`
- 受影响的脚本 / 任务：`infra/cdk/package.json` 里的 `deploy` / `destroy`
- 受影响的数据结构 / 配置：`pipeline-config.json` 的资源命名继续作为单一来源；API 入口从 EDGE 改为 REGIONAL
- 是否影响默认 PR 门禁：否
- 是否影响部署 / 回滚：是，部署入口变成三个顶层 stack，回滚和销毁顺序更清晰

## 详细说明

### 1. 主要改动

- 改动点 1：新增 `FoundationStack`、`ComputeStack`、`ApiStack`，并在 `infra/cdk/bin/app.ts` 中替换原先的单一 `PipelineStack` 入口。
- 改动点 2：把 REST API 入口单独拆出来，并将 `EndpointType.EDGE` 改为 `EndpointType.REGIONAL`。
- 改动点 3：把 deploy / destroy 命令下沉到 `infra/cdk/package.json`，workflow 只负责调用统一脚本。

### 2. 设计选择

- 为什么采用当前方案：先把顶层 stack 职责拆开，再让脚本和文档跟上；这样结构变化先落地，后续再按需要进一步拆 asset 或细化销毁策略。
- 备选方案是什么：继续保留单栈，只在 TypeScript 里做 `Promise.all` 或其它异步调度优化；或者仅改脚本不改 stack 边界。
- 为什么没有选择备选方案：单栈并发对 deploy / destroy 的真实收益有限，且和仓库当前的资源边界不匹配。

### 3. 兼容性

- 是否向后兼容：部分兼容。资源命名仍然来自 `pipeline-config.json`，但 CDK 入口已从单栈变为三个顶层 stack。
- 是否需要迁移：不需要额外数据迁移，但需要重新合成和部署栈。
- 是否需要重建索引 / 重新部署 / 重新生成产物：需要重新部署；`cdk synth` 依赖的 release assets 逻辑未变。
- 是否引入新环境变量 / 新配置项：未引入新的必填环境变量。

### 4. 代码 / 文件清单

- 新增文件：`infra/cdk/lib/foundation-stack.ts`、`infra/cdk/lib/compute-stack.ts`、`infra/cdk/lib/api-stack.ts`、`infra/cdk/lib/pipeline/api.ts`、`infra/cdk/lib/pipeline/bindings.ts`
- 修改文件：`infra/cdk/bin/app.ts`、`infra/cdk/lib/pipeline-stack.ts`、`infra/cdk/lib/pipeline/compute.ts`、`infra/cdk/lib/pipeline/roles.ts`、`infra/cdk/package.json`、`docs/*.md`、`.github/workflows/*.yml`、`tools/ci/tests/deployment_helpers/test_cdk_workflows.py`
- 删除文件：无
- 重命名文件：无

## 验证

请明确列出实际执行过的验证步骤，而不是只写“已测试”。

### 本地验证

- 执行的命令：`MCP_ALLOW_PLACEHOLDER_ASSETS=true npm --prefix infra/cdk exec -- cdk synth`
- 命令输出结论：成功合成三个顶层 stack，分别是 `mcp-doc-pipeline-prod-foundation`、`mcp-doc-pipeline-prod-compute`、`mcp-doc-pipeline-prod-api`
- 相关截图 / 日志 / 链接：无

### 自动化验证

- [x] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [x] 构建检查
- [ ] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：`uv run --project services pytest`，`npm --prefix infra/cdk exec -- cdk synth`
- 失败项：无
- 未执行项及原因：workflow / CI 仅在 GitHub Actions 上执行

## 风险与回滚

说明这次 PR 最可能带来的风险，以及如果需要回退，应该怎么回退。

- 主要风险：拆栈后 deploy / destroy 的真实顺序更依赖 stack 依赖配置；如果后续继续拆分资源边界，需要同步保持命名和权限一致。
- 风险缓解方式：保留资源命名单一来源，保留 placeholder assets 的 destroy 路径，并补了 workflow / 命令回归测试。
- 回滚方式：回退这一组提交，恢复单一 `PipelineStack` 入口和原先的 workflow / scripts。
- 回滚后遗留影响：已经部署到云上的资源不会自动回滚，需要按原先 destroy 流程单独清理。
- 是否需要灰度：不需要，但建议先在非生产环境验证拆分后的 synth / deploy 顺序。

## 对业务 / 运维的影响

- 是否影响线上行为：API Gateway 入口改成 `REGIONAL`，其余业务逻辑不变。
- 是否影响部署流程：是，deploy / destroy 入口现在由三个顶层 stack 组成，脚本也换成统一的 CDK 参数。
- 是否影响监控 / 告警：不直接影响。
- 是否影响成本 / 性能：有机会缩短 destroy 和部分 deploy 流程，但主要收益来自 stack 拆分，不是函数内部异步优化。
- 是否影响运维手册：是，相关文档已经同步。

## 截图 / 录屏 / 示例

如果改动涉及 UI、文档排版、流程演示或输出格式，请在这里补充。

- 截图：无
- 录屏：无
- 示例输入：无
- 示例输出：无

## 待确认事项

如果还有未决问题，请在这里列出，并标明由谁确认。

- [ ] 后续是否继续把 data plane 再拆到更细粒度的 stack
- [ ] 是否需要进一步压缩 Lambda / Layer asset 数量
- [ ] 是否要在 deploy 入口里继续评估 `--asset-parallelism` 的可行性

## Reviewer 关注点

告诉 reviewer 重点看哪里，减少来回沟通。

- 请重点检查：stack 边界是否合理、API 入口是否真的已经从 EDGE 切到 REGIONAL、deploy / destroy 脚本是否与文档一致
- 请重点验证：`cdk synth` 是否能稳定生成三个顶层 stack
- 请重点确认：`Closes #42` 是否位于 PR 正文前部且是普通文本

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
