### PR TITLE
fix(destroy): update paths after infra/ directory restructure

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install CDK toolchain
         run: |
           set -euo pipefail
-          npm ci --prefix infra/cdk
+          npm ci --prefix ocr-service/infra/cdk
 
       # EN: Prefer OIDC-based AWS credentials when a role ARN is configured.
       # CN: 当配置了 role ARN 时优先使用基于 OIDC 的 AWS 凭据。
@@ -108,9 +108,9 @@ jobs:
 
           node - <<'NODE'
           const fs = require('node:fs');
-          const config = JSON.parse(fs.readFileSync('infra/pipeline-config.json', 'utf8'));
+          const config = JSON.parse(fs.readFileSync('ocr-service/infra/pipeline-config.json', 'utf8'));
           if (config.name_prefix !== process.env.INPUT_NAME_PREFIX) {
-            throw new Error(`name_prefix does not match infra/pipeline-config.json: ${config.name_prefix}`);
+            throw new Error(`name_prefix does not match ocr-service/infra/pipeline-config.json: ${config.name_prefix}`);
           }
           NODE
         env:
@@ -121,4 +121,4 @@ jobs:
       - name: Destroy AWS resources with CDK
         run: |
           set -euo pipefail
-          npm --prefix infra/cdk run destroy
+          npm --prefix ocr-service/infra/cdk run destroy

--- a/tools/ci/tests/ci/test_validate_workflows.py
+++ b/tools/ci/tests/ci/test_validate_workflows.py
@@ -255,7 +255,7 @@ def test_destroy_workflow_uses_root_pipeline_config() -> None:
 
     assert "name: Destroy" in text
     assert "workflow_dispatch" in text
-    assert "infra/pipeline-config.json" in text
+    assert "ocr-service/infra/pipeline-config.json" in text
     assert "scripts/deploy/pipeline-config.json" not in text
 
 

--- a/tools/ci/validate_workflows.py
+++ b/tools/ci/validate_workflows.py
@@ -389,8 +389,8 @@ def _assert_destroy_alignment(errors: list[str]) -> None:
     """EN: Ensure the destroy workflow reads the infra/ pipeline config instead of the old root path.
     CN: 确保 destroy workflow 读取 infra/ 下的 pipeline 配置，而不是旧的根目录路径。"""
     destroy_text = (REPO_ROOT / ".github" / "workflows" / "destroy.yml").read_text(encoding="utf-8")
-    if "infra/pipeline-config.json" not in destroy_text:
-        errors.append(".github/workflows/destroy.yml must read infra/pipeline-config.json")
+    if "ocr-service/infra/pipeline-config.json" not in destroy_text:
+        errors.append(".github/workflows/destroy.yml must read ocr-service/infra/pipeline-config.json")
     if "scripts/deploy/pipeline-config.json" in destroy_text:
         errors.append(".github/workflows/destroy.yml must not reference scripts/deploy/pipeline-config.json")
 


### PR DESCRIPTION
## Summary

- Fix `destroy.yml` npm ci/install step referencing old `infra/cdk` path (moved to `ocr-service/infra/cdk`)
- Fix `destroy.yml` Node.js step reading `infra/pipeline-config.json` (moved to `ocr-service/infra/pipeline-config.json`)
- Sync `_assert_destroy_alignment` CI lint check and its unit test to validate the new path

## Test plan

- [ ] Verify `destroy.yml` lint passes: `python -m tools.ci.validate_workflows`
- [ ] Confirm no `infra/cdk` or root-level `infra/pipeline-config.json` references remain in `destroy.yml`