### PR TITLE
feat: add workflow_call trigger for reusable workflows

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -19,6 +19,23 @@ on:
         description: Type the exact name prefix again to confirm destructive teardown
         required: true
         type: string
+  workflow_call:
+    inputs:
+      name_prefix:
+        description: Deployment name prefix used to derive resource names
+        required: false
+        default: mcp-doc-pipeline-prod
+        type: string
+      region:
+        description: AWS region override; leave empty to use the repository secret
+        required: false
+        default: ""
+        type: string
+      confirm_destroy:
+        description: Type the exact name prefix again to confirm destructive teardown
+        required: false
+        default: mcp-doc-pipeline-prod
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -13,6 +13,18 @@ on:
         description: Type the release tag again to confirm deployment
         required: true
         type: string
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Release tag to deploy
+        required: false
+        default: main
+        type: string
+      confirm_release_tag:
+        description: Type the release tag again to confirm deployment
+        required: false
+        default: main
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- 给 `prod-deploy.yml` 和 `destroy.yml` 添加 `workflow_call` 触发器
- 现在这两个 workflow 既可以手动触发（`workflow_dispatch`），也可以被其他仓库作为 reusable workflow 调用（`workflow_call`）

## Test plan

- [ ] 在 serverless-kb-mcp 仓库手动触发 `prod-deploy` 和 `destroy` workflow 验证不受影响
- [ ] 在其他仓库用 `uses: owokit/serverless-kb-mcp/.github/workflows/prod-deploy.yml@feat/add-workflow-call-trigger` 调用验证