### PR TITLE
fix: reference setup-runtime as a remote action

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up runtime
-        uses: ./.github/actions/setup-runtime
+        uses: owokit/serverless-kb-mcp/.github/actions/setup-runtime@main
         with:
           setup-node: true
           setup-python: true


### PR DESCRIPTION
修复 `Prod Deploy` 在被其它仓库复用时，因本地 action 解析到调用方仓库而失败的问题。

变更仅限一处：
- 把 `uses: ./.github/actions/setup-runtime` 改为同仓库的远程 action 引用

这样 reusable workflow 在外部仓库调用时，不再依赖调用方仓库是否存在 `.github/actions/setup-runtime`。