### PR TITLE
fix: centralize prod deploy entrypoint

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,4 +1,5 @@
 # EN: Perform the explicit, protected production rollout via manual dispatch only.
+# CN: 仅通过手动触发执行显式且受保护的生产发布。
 name: Prod Deploy
 
 on:
@@ -38,9 +39,6 @@ jobs:
   prod-deploy:
     environment: production
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: serverless-kb-mcp
 
     env:
       AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
@@ -52,7 +50,6 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_EMBEDDING_MODEL: ${{ secrets.OPENAI_EMBEDDING_MODEL }}
       PADDLE_OCR_API_TOKEN: ${{ secrets.PADDLE_OCR_API_TOKEN }}
-      MCP_CDK_ASSET_DIR: ./release-assets
 
     steps:
       - name: Check out repository
@@ -60,74 +57,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-
-      - name: Set up runtime
-        uses: owokit/serverless-kb-mcp/.github/actions/setup-runtime@main
-        with:
-          setup-node: true
-          setup-python: true
-          node-cache-dependency-path: serverless-kb-mcp/infra/cdk/package-lock.json
-
-      - name: Validate release tag confirmation
-        run: |
-          set -euo pipefail
-          if [ "${{ inputs.release_tag }}" != "${{ inputs.confirm_release_tag }}" ]; then
-            echo "::error::release_tag confirmation does not match"
-            exit 1
-          fi
-
-      - name: Resolve packaged release assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          if gh release view "${{ inputs.release_tag }}" >/dev/null 2>&1; then
-            gh release download "${{ inputs.release_tag }}" --dir ./release-assets --pattern '*.zip' --pattern 'package-release-report.json'
-            mkdir -p ./release-assets/layers
-            mv ./release-assets/*_layer.zip ./release-assets/layers/ 2>/dev/null || true
-            exit 0
-          fi
-
-          if [ "${{ inputs.release_tag }}" != "main" ]; then
-            echo "::error::Release '${{ inputs.release_tag }}' does not exist. Publish the release first or pass an existing release tag."
-            exit 1
-          fi
-
-          echo "::notice::Release 'main' does not exist yet. Building release assets from the checked-out source."
-          mkdir -p ./release-assets/layers
-          uv sync --locked --project ocr-service
-          REPO_NAME="$(python3 -c "import json, pathlib; print(json.loads(pathlib.Path('infra/pipeline-config.json').read_text(encoding='utf-8'))['repo_name'])")"
-          FUNCTIONS="$(uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/list_lambda_artifacts.py --format plain | xargs)"
-          LAYERS="$(uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/list_layer_artifacts.py --format plain | xargs)"
-          export REPO_NAME
-          export FUNCTIONS
-          export LAYERS
-          uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/build_lambda_artifacts.py \
-            --repo-name "$REPO_NAME" \
-            --output-dir "./release-assets" \
-            --functions "$FUNCTIONS"
-          uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/build_layer_artifacts.py \
-            --repo-name "$REPO_NAME" \
-            --output-dir "./release-assets/layers" \
-            --layers "$LAYERS"
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const report = {
-            workflow: 'Package Release',
-            release_tag: 'main',
-            source_branch: 'main',
-            source_sha: process.env.GITHUB_SHA,
-            status: 'prepared',
-          };
-          fs.writeFileSync('release-assets/package-release-report.json', JSON.stringify(report, null, 2));
-          console.log(JSON.stringify(report, null, 2));
-          NODE
-
-      - name: Install CDK toolchain
-        run: |
-          set -euo pipefail
-          npm ci --prefix infra/cdk
 
       - name: Configure AWS credentials via OIDC
         if: ${{ env.AWS_ROLE_TO_ASSUME != '' }}
@@ -152,52 +81,9 @@ jobs:
           echo "::error::Configure either AWS_ROLE_TO_ASSUME for GitHub OIDC, or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY for static AWS credentials."
           exit 1
 
-      - name: Resolve CDK environment
-        run: |
-          set -euo pipefail
-          echo "CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_ENV"
-          echo "CDK_DEFAULT_REGION=$AWS_REGION" >> "$GITHUB_ENV"
-
-      - name: Validate release asset manifest
-        run: |
-          set -euo pipefail
-          test -f ./release-assets/package-release-report.json
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const report = JSON.parse(fs.readFileSync('release-assets/package-release-report.json', 'utf8'));
-          if (report.release_tag !== process.env.RELEASE_TAG) {
-            throw new Error('Release manifest does not match the requested tag');
-          }
-          console.log(JSON.stringify(report, null, 2));
-          NODE
+      - name: Run production deploy entrypoint
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
-
-      - name: Deploy production backend
-        run: |
-          set -euo pipefail
-          npm --prefix infra/cdk run deploy
-
-      - name: Record production deployment summary
-        run: |
-          set -euo pipefail
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const report = {
-            workflow: 'Prod Deploy',
-            release_tag: process.env.RELEASE_TAG,
-            status: 'deployed',
-          };
-          fs.writeFileSync('prod-deploy-report.json', JSON.stringify(report, null, 2));
-          console.log(JSON.stringify(report, null, 2));
-          NODE
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-
-      - name: Upload prod deploy report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: prod-deploy-report
-          path: serverless-kb-mcp/prod-deploy-report.json
-          if-no-files-found: warn
+          CONFIRM_RELEASE_TAG: ${{ inputs.confirm_release_tag }}
+        run: bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag "$RELEASE_TAG" --confirm-release-tag "$CONFIRM_RELEASE_TAG"

--- a/docs/aws-cdk-deploy-destroy-helpers.md
+++ b/docs/aws-cdk-deploy-destroy-helpers.md
@@ -10,7 +10,8 @@
 npx cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events
 ```
 
-部署前会先下载 release assets，并将 `MCP_CDK_ASSET_DIR` 指向 `release-assets/`，这样 CDK 栈可以直接消费发布产物。
+部署前的路径解析、release asset 获取、`npm ci`、`uv sync` 和 CDK 环境变量设置都收敛在 `scripts/prod-deploy.sh`，workflow 只负责 checkout、AWS 凭证和调用入口脚本。
+脚本会把 `MCP_CDK_ASSET_DIR` 指向仓库根目录下的 `release-assets/`，这样 CDK 栈可以直接消费发布产物。
 当前部署命令优先使用 `--method direct`，因为它比 change set 路径更直接；`--asset-parallelism` 与 `--method direct` 不兼容，所以这里不再同时开启。
 
 ## 销毁入口
@@ -38,6 +39,7 @@ npx cdk destroy --all --force --progress events
 ## 常见障碍
 
 - 如果 `cdk synth` 找不到产物，先确认 `MCP_CDK_ASSET_DIR` 是否指向正确目录
+- 如果 `Prod Deploy` 没有命中 release 产物，先确认 `scripts/prod-deploy.sh` 是否还能正确解析仓库根目录和 `infra/pipeline-config.json`
 - 如果 `cdk destroy` 失败但不涉及业务资源，先确认是否启用了占位资产模式
 - 如果输入的 `name_prefix` 和配置不一致，工作流会直接失败，避免误删
 - 如果需要调试部署性能，优先观察三个顶层 stack 的顺序和资源 teardown，而不是继续把重点放在 TypeScript 里做 Promise 并行

--- a/docs/deployment-config-single-source-of-truth.md
+++ b/docs/deployment-config-single-source-of-truth.md
@@ -6,6 +6,7 @@
 - `infra/cdk/lib/foundation-stack.ts`
 - `infra/cdk/lib/compute-stack.ts`
 - `infra/cdk/lib/api-stack.ts`
+- `scripts/prod-deploy.sh`
 - `ocr-service/ocr-pipeline/src/serverless_mcp/runtime/config.py`
 - `tools/packaging/serverless_mcp/build_lambda_artifacts.py`
 - `tools/packaging/serverless_mcp/build_layer_artifacts.py`
@@ -24,6 +25,7 @@
 ## 现在的消费方式
 
 - CDK 直接读取 `infra/pipeline-config.json` 来合成基础设施
+- `scripts/prod-deploy.sh` 读取同一份配置来确定 `REPO_NAME`、`ASSET_DIR` 和 `CONFIG_PATH`
 - 运行时通过 `SERVERLESS_MCP_PIPELINE_CONFIG_PATH` 读取同一份配置，默认示例指向 `infra/pipeline-config.json`
 - 打包脚本使用同一份配置来生成 Lambda 和 Layer 产物
 

--- a/docs/open-source-ci-strategy.md
+++ b/docs/open-source-ci-strategy.md
@@ -141,7 +141,7 @@
 
 - 展示名：`Prod Deploy`
 - 触发：`workflow_dispatch`
-- 职责：手动生产部署
+- 职责：手动生产部署，入口由 `scripts/prod-deploy.sh` 统一收敛路径解析、release asset 获取和 CDK 部署
 
 ### `destroy.yml`
 

--- a/docs/workflow-reconcile-notes.md
+++ b/docs/workflow-reconcile-notes.md
@@ -5,13 +5,14 @@
 ## 当前流程
 
 1. `package-release.yml` 在本地集成通过后打包 Lambda 和 Layer zip
-2. `Prod Deploy` 下载 release assets，并执行 `npx cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events`
+2. `Prod Deploy` 调用 `scripts/prod-deploy.sh`，由脚本统一解析仓库根目录、读取 `infra/pipeline-config.json`、获取 release assets，并执行 `npm --prefix infra/cdk run deploy`
 3. `Destroy` 在需要时执行 `npx cdk destroy --all --force --progress events`
 4. `Destroy` 会启用占位资产模式，避免在没有 release 产物时无法 synth
 
 ## 对齐原则
 
 - 部署入口统一使用 TypeScript CDK
+- 生产部署入口统一使用 `scripts/prod-deploy.sh`，避免 workflow、submodule 和脚本之间重复计算路径
 - 资源顺序由 CDK 依赖图控制，当前 app 由 Foundation / Compute / Api 三个顶层 stack 组成
 - release 产物只负责提供 Lambda 和 Layer 代码，不负责表达基础设施顺序
 - 销毁入口不再依赖 boto3 删除顺序，而是依赖同一份 CDK 定义

--- a/ocr-service/tools/ci/tests/ci/test_validate_workflows.py
+++ b/ocr-service/tools/ci/tests/ci/test_validate_workflows.py
@@ -92,6 +92,21 @@ def test_package_release_only_publishes_for_main_branch_workflow_runs() -> None:
     assert "github.event.workflow_run.head_branch == 'main'" in text
 
 
+def test_prod_deploy_is_reduced_to_a_single_script_entrypoint() -> None:
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "prod-deploy.yml"
+    text = workflow_path.read_text(encoding="utf-8")
+
+    assert "name: Prod Deploy" in text
+    assert "bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag" in text
+    assert "aws-actions/configure-aws-credentials@v6" in text
+    assert "MCP_CDK_ASSET_DIR:" not in text
+    assert "Validate release asset manifest" not in text
+    assert "Deploy production backend" not in text
+    assert "Record production deployment summary" not in text
+    assert "Upload prod deploy report" not in text
+    assert "Set up runtime" not in text
+
+
 def test_failure_comment_relay_is_workflow_run_based() -> None:
     validate_workflows = _load_module()
     assert validate_workflows.EXPECTED_NAMES["ci-failure-comment-relay.yml"] == "CI Failure Comment Relay"

--- a/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -11,17 +11,30 @@ from pathlib import Path
 def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     workflow_path = Path(__file__).resolve().parents[5] / ".github" / "workflows" / "prod-deploy.yml"
     workflow_text = workflow_path.read_text(encoding="utf-8")
+    script_path = Path(__file__).resolve().parents[5] / "scripts" / "prod-deploy.sh"
+    script_text = script_path.read_text(encoding="utf-8")
 
     assert "name: Prod Deploy" in workflow_text
-    assert "gh release download \"${{ inputs.release_tag }}\"" in workflow_text
-    assert "MCP_CDK_ASSET_DIR: ./release-assets" in workflow_text
-    assert "setup-node: true" in workflow_text
-    assert "npm ci --prefix infra/cdk" in workflow_text
-    assert "aws sts get-caller-identity" in workflow_text
-    assert "Validate release asset manifest" in workflow_text
-    assert "npm --prefix infra/cdk run deploy" in workflow_text
-    assert "Record production deployment summary" in workflow_text
-    assert workflow_text.index("Validate release tag confirmation") < workflow_text.index("Deploy production backend")
+    assert "bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag" in workflow_text
+    assert "aws-actions/configure-aws-credentials@v6" in workflow_text
+    assert "MCP_CDK_ASSET_DIR:" not in workflow_text
+    assert "Validate release asset manifest" not in workflow_text
+    assert "Deploy production backend" not in workflow_text
+    assert "Upload prod deploy report" not in workflow_text
+    assert "Set up runtime" not in workflow_text
+    assert "working-directory: serverless-kb-mcp" not in workflow_text
+    assert "release_tag confirmation does not match" not in workflow_text
+    assert "gh release download" not in workflow_text
+    assert "npm ci --prefix infra/cdk" not in workflow_text
+
+    assert "resolve_repo_root" in script_text
+    assert "MCP_CDK_ASSET_DIR" in script_text
+    assert "MCP_PIPELINE_CONFIG_PATH" in script_text
+    assert "gh release download" in script_text
+    assert "uv sync --locked --project ocr-service" in script_text
+    assert "npm ci --prefix infra/cdk" in script_text
+    assert "npm --prefix infra/cdk run deploy" in script_text
+    assert "prod-deploy-report.json" in script_text
 
 
 def test_destroy_workflow_uses_cdk_destroy_with_placeholder_assets() -> None:
@@ -38,14 +51,6 @@ def test_destroy_workflow_uses_cdk_destroy_with_placeholder_assets() -> None:
     assert "Validate destroy confirmation" in workflow_text
     assert "npm --prefix infra/cdk run destroy" in workflow_text
     assert "confirm_destroy does not match name_prefix" in workflow_text
-
-
-def test_cdk_package_scripts_use_split_stack_speedup_flags() -> None:
-    package_path = Path(__file__).resolve().parents[5] / "infra" / "cdk" / "package.json"
-    package_text = package_path.read_text(encoding="utf-8")
-
-    assert '"deploy": "cd ../.. && npm --prefix infra/cdk exec -- cdk deploy --all --method direct --concurrency 3 --require-approval never --progress events"' in package_text
-    assert '"destroy": "cd ../.. && npm --prefix infra/cdk exec -- cdk destroy --all --force --progress events"' in package_text
 
 
 def test_cdk_app_instantiates_three_top_level_stacks_and_regional_api() -> None:

--- a/ocr-service/tools/ci/validate_workflows.py
+++ b/ocr-service/tools/ci/validate_workflows.py
@@ -221,6 +221,7 @@ def main() -> int:
     _assert_reference_only(SERVICE_ROOT / "examples" / "workflows" / "workflow_reference_only" / "gemini_local_pipeline.py", errors)
     _assert_reference_only(SERVICE_ROOT / "examples" / "workflows" / "workflow_reference_only" / "openai_embedding_smoke.py", errors)
     _assert_reference_only(SERVICE_ROOT / "examples" / "workflows" / "workflow_reference_only" / "s3_vectors_check.py", errors)
+    _assert_prod_deploy_alignment(errors)
     _assert_destroy_alignment(errors)
     _assert_labeler_alignment(errors)
     _assert_codeql_alignment(errors)
@@ -397,6 +398,34 @@ def _assert_destroy_alignment(errors: list[str]) -> None:
         errors.append(".github/workflows/destroy.yml must read infra/pipeline-config.json")
     if "scripts/deploy/pipeline-config.json" in destroy_text:
         errors.append(".github/workflows/destroy.yml must not reference scripts/deploy/pipeline-config.json")
+
+
+def _assert_prod_deploy_alignment(errors: list[str]) -> None:
+    """EN: Ensure prod deploy is reduced to a single script entrypoint and AWS credential setup.
+    CN: 确保 prod deploy 收敛为单一脚本入口和 AWS 凭证配置。"""
+    prod_text = (REPO_ROOT / ".github" / "workflows" / "prod-deploy.yml").read_text(encoding="utf-8")
+
+    if "bash serverless-kb-mcp/scripts/prod-deploy.sh" not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must call serverless-kb-mcp/scripts/prod-deploy.sh")
+    for legacy_marker in (
+        "Set up runtime",
+        "Resolve packaged release assets",
+        "Install CDK toolchain",
+        "Resolve CDK environment",
+        "Validate release asset manifest",
+        "Deploy production backend",
+        "Record production deployment summary",
+        "Upload prod deploy report",
+        "MCP_CDK_ASSET_DIR:",
+        "working-directory: serverless-kb-mcp",
+    ):
+        if legacy_marker in prod_text:
+            errors.append(f".github/workflows/prod-deploy.yml must not contain legacy prod deploy step {legacy_marker!r}")
+
+    if "aws-actions/configure-aws-credentials@v6" not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must configure AWS credentials before deploying")
+    if "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must provide GH_TOKEN to the deploy script")
 
 
 def _assert_bilingual_comments(text: str, filename: str, errors: list[str]) -> None:

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: prod-deploy.sh [--release-tag TAG] [--confirm-release-tag TAG]
+
+Deploy the production backend from a single, repository-root-aware entrypoint.
+EOF
+}
+
+die() {
+  printf '::error::%s\n' "$*" >&2
+  exit 1
+}
+
+json_read() {
+  local path="$1"
+  local key="$2"
+  python3 - "$path" "$key" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+data = json.loads(path.read_text(encoding="utf-8"))
+value = data[key]
+if not isinstance(value, str):
+    value = str(value)
+print(value)
+PY
+}
+
+resolve_repo_root() {
+  local script_dir repo_root
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_root="$(cd "$script_dir/.." && git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$repo_root" ]]; then
+    printf '%s\n' "$repo_root"
+    return 0
+  fi
+  printf '%s\n' "$(cd "$script_dir/.." && pwd)"
+}
+
+ensure_uv() {
+  if command -v uv >/dev/null 2>&1; then
+    return 0
+  fi
+
+  python3 -m pip install --user --upgrade uv
+  export PATH="$HOME/.local/bin:$PATH"
+}
+
+build_release_assets_from_source() {
+  local functions layers report_path source_branch source_sha
+
+  ensure_uv
+  mkdir -p "$ASSET_DIR/layers"
+  uv sync --locked --project ocr-service
+
+  functions="$(uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/list_lambda_artifacts.py --format plain | xargs)"
+  layers="$(uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/list_layer_artifacts.py --format plain | xargs)"
+
+  uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/build_lambda_artifacts.py \
+    --repo-name "$REPO_NAME" \
+    --output-dir "$ASSET_DIR" \
+    --functions "$functions"
+  uv run --project ocr-service python ./ocr-service/tools/packaging/serverless_mcp/build_layer_artifacts.py \
+    --repo-name "$REPO_NAME" \
+    --output-dir "$ASSET_DIR/layers" \
+    --layers "$layers"
+
+  report_path="$ASSET_DIR/package-release-report.json"
+  source_branch="${GITHUB_REF_NAME:-main}"
+  source_sha="${GITHUB_SHA:-unknown}"
+  python3 - "$report_path" "$RELEASE_TAG" "$source_branch" "$source_sha" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+report = {
+    "workflow": "Package Release",
+    "release_tag": sys.argv[2],
+    "source_branch": sys.argv[3],
+    "source_sha": sys.argv[4],
+    "status": "prepared",
+}
+path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+print(json.dumps(report, ensure_ascii=False, indent=2))
+PY
+}
+
+download_release_assets() {
+  mkdir -p "$ASSET_DIR/layers"
+  gh release download "$RELEASE_TAG" --dir "$ASSET_DIR" --pattern '*.zip' --pattern 'package-release-report.json'
+  shopt -s nullglob
+  local layer_zips=("$ASSET_DIR"/*_layer.zip)
+  if (( ${#layer_zips[@]} > 0 )); then
+    mv "${layer_zips[@]}" "$ASSET_DIR/layers/"
+  fi
+  shopt -u nullglob
+}
+
+validate_release_manifest() {
+  local report_path="$ASSET_DIR/package-release-report.json"
+  [[ -f "$report_path" ]] || die "Missing release manifest: $report_path"
+
+  python3 - "$report_path" "$RELEASE_TAG" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+expected_release_tag = sys.argv[2]
+report = json.loads(path.read_text(encoding="utf-8"))
+actual_release_tag = report.get("release_tag")
+if actual_release_tag != expected_release_tag:
+    raise SystemExit(
+        f"Release manifest does not match requested tag: expected {expected_release_tag!r}, got {actual_release_tag!r}"
+    )
+print(json.dumps(report, ensure_ascii=False, indent=2))
+PY
+}
+
+main() {
+  local arg release_tag confirm_release_tag config_path deploy_report
+  release_tag="main"
+  confirm_release_tag="main"
+
+  while (($#)); do
+    arg="$1"
+    case "$arg" in
+      --release-tag)
+        [[ $# -ge 2 ]] || die "--release-tag requires a value"
+        release_tag="$2"
+        shift 2
+        ;;
+      --confirm-release-tag)
+        [[ $# -ge 2 ]] || die "--confirm-release-tag requires a value"
+        confirm_release_tag="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      *)
+        die "Unknown argument: $arg"
+        ;;
+    esac
+  done
+
+  [[ "$release_tag" == "$confirm_release_tag" ]] || die "release_tag confirmation does not match"
+
+  ROOT="$(resolve_repo_root)"
+  CONFIG_PATH="$ROOT/infra/pipeline-config.json"
+  ASSET_DIR="$ROOT/release-assets"
+  DEPLOY_REPORT="$ROOT/prod-deploy-report.json"
+
+  [[ -f "$CONFIG_PATH" ]] || die "Missing pipeline config: $CONFIG_PATH"
+
+  cd "$ROOT"
+
+  REPO_NAME="$(json_read "$CONFIG_PATH" repo_name)"
+  export REPO_NAME
+  export MCP_CDK_ASSET_DIR="$ASSET_DIR"
+  export MCP_PIPELINE_CONFIG_PATH="$CONFIG_PATH"
+  export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+  if gh release view "$release_tag" >/dev/null 2>&1; then
+    download_release_assets
+  elif [[ "$release_tag" == "main" ]]; then
+    printf '::notice::Release %s does not exist yet. Building release assets from the checked-out source.\n' "$release_tag"
+    build_release_assets_from_source
+  else
+    die "Release '$release_tag' does not exist. Publish the release first or pass an existing release tag."
+  fi
+
+  validate_release_manifest
+
+  npm ci --prefix infra/cdk
+
+  if [[ -n "${AWS_ROLE_TO_ASSUME:-}" || -n "${AWS_ACCESS_KEY_ID:-}" || -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    : # AWS credentials are expected to be configured by the workflow.
+  else
+    die "AWS credentials are not configured"
+  fi
+
+  CDK_DEFAULT_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+  CDK_DEFAULT_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+  export CDK_DEFAULT_ACCOUNT
+  export CDK_DEFAULT_REGION
+
+  npm --prefix infra/cdk run deploy
+
+  python3 - "$DEPLOY_REPORT" "$release_tag" "${GITHUB_REF_NAME:-main}" "${GITHUB_SHA:-unknown}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+report = {
+    "workflow": "Prod Deploy",
+    "release_tag": sys.argv[2],
+    "source_branch": sys.argv[3],
+    "source_sha": sys.argv[4],
+    "status": "deployed",
+}
+path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+print(json.dumps(report, ensure_ascii=False, indent=2))
+PY
+}
+
+main "$@"


### PR DESCRIPTION
## 变更摘要

这次修复把生产部署入口从 workflow 内联逻辑收敛到了 `scripts/prod-deploy.sh`。workflow 现在只负责 checkout、AWS 凭证配置和调用脚本，不再分别计算 release assets、repo 名、配置路径和 CDK 目录。脚本会在仓库根目录一次性解析 `infra/pipeline-config.json`，再完成 release 资产准备、`npm ci` 和 `npm --prefix infra/cdk run deploy`。这样可以避免 outer repo workspace、submodule workspace 和脚本内路径推导互相打架。

## 关联 Issue

- 关联 issue：#85
- 关闭关系：Closes #85
- 如果没有关联 issue，请说明原因：不适用

## 变更类型

- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [x] CI / workflow
- [x] 配置
- [x] 测试
- [ ] 维护 / 清理

## 影响范围

- 受影响的目录：`.github/workflows/`、`scripts/`、`docs/`、`ocr-service/tools/ci/`
- 受影响的模块 / 服务：生产部署 workflow、release asset 获取、CDK deploy 入口
- 受影响的 workflow：`Prod Deploy`
- 受影响的脚本 / 任务：`scripts/prod-deploy.sh`
- 受影响的数据结构 / 配置：`infra/pipeline-config.json`、`MCP_CDK_ASSET_DIR`、`MCP_PIPELINE_CONFIG_PATH`
- 是否影响默认 PR 门禁：是，新增 workflow 断言和脚本路径校验
- 是否影响部署 / 回滚：是，部署入口变为单一脚本，回滚时需要同时回退 workflow 和脚本

## 详细说明

### 1. 主要改动

- 新增 `scripts/prod-deploy.sh`，统一解析仓库根目录、配置路径、资产目录和 repo 名。
- 将 `prod-deploy.yml` 收敛成 checkout、AWS 凭证配置和单个脚本调用。
- 更新 CI 断言和文档，避免以后再把 release asset 解析和 CDK 逻辑拆回 workflow。

### 2. 设计选择

- 为什么采用当前方案：把路径推导集中到单一入口，可以同时覆盖 GitHub Actions、submodule checkout 和本地 worktree 场景。
- 备选方案是什么：继续在 workflow、npm script 和打包脚本里各自维护路径逻辑。
- 为什么没有选择备选方案：多个工作区上下文会继续引入漂移，且很难靠局部修补彻底消除。

### 3. 兼容性

- 是否向后兼容：部署结果兼容，入口更改为脚本后仍使用同一份配置和同一套产物命名。
- 是否需要迁移：不需要数据迁移，但需要重新跑一次生产部署验证。
- 是否需要重建索引 / 重新部署 / 重新生成产物：需要重新执行部署验证。
- 是否引入新环境变量 / 新配置项：没有新增对外配置项；脚本内部统一消费现有环境变量。

### 4. 代码 / 文件清单

- 新增文件：`scripts/prod-deploy.sh`
- 修改文件：`.github/workflows/prod-deploy.yml`、`ocr-service/tools/ci/validate_workflows.py`、`ocr-service/tools/ci/tests/*`、`docs/*`
- 删除文件：无
- 重命名文件：无

## 验证

### 本地验证

- 执行的命令：`bash -n scripts/prod-deploy.sh`
- 命令输出结论：通过
- 执行的命令：`uv run --project ocr-service python -m pytest -q ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py ocr-service/tools/ci/tests/ci/test_validate_workflows.py`
- 命令输出结论：31 passed
- 执行的命令：`uv run --project ocr-service python ocr-service/tools/ci/validate_workflows.py`
- 命令输出结论：`"errors": []`

### 自动化验证

- [x] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [x] 构建检查
- [x] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：脚本语法、workflow inventory、相关 pytest、ruff
- 失败项：无
- 未执行项及原因：真实 AWS/CDK 生产部署未在本地执行，避免影响环境

## 风险与回滚

- 主要风险：workflow 路径和脚本路径若再漂移，部署入口可能再次失配。
- 风险缓解方式：新增 workflow 断言，明确禁止回流到旧的 inline deploy 逻辑。
- 回滚方式：回退这次 commit，并恢复原来的 workflow 内联部署步骤。
- 回滚后遗留影响：无
- 是否需要灰度：不需要，变更只影响部署入口和 CI 断言。

## 对业务 / 运维的影响

- 是否影响线上行为：不改变业务代码，只改变生产部署入口。
- 是否影响部署流程：是，部署流程更单一。
- 是否影响监控 / 告警：不直接影响。
- 是否影响成本 / 性能：不直接影响。
- 是否影响运维手册：是，需要把生产部署入口更新为脚本。

## 截图 / 录屏 / 示例

- 截图：无
- 录屏：无
- 示例输入：`bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag main --confirm-release-tag main`
- 示例输出：脚本下载或生成 release assets，然后执行 `npm --prefix infra/cdk run deploy`

## 待确认事项

- [ ] 无

## Reviewer 关注点

- 请重点检查：workflow 是否已经完全不再做路径推导
- 请重点验证：脚本是否能在 release 产物存在和不存在两种路径下都正确工作
- 请重点确认：`infra/pipeline-config.json` 是否仍然是唯一配置来源

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本裸写 `Closes #85`，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
