### PR TITLE
fix: export release tag in prod deploy script

### DIFF
--- a/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -30,6 +30,7 @@ def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     assert "resolve_repo_root" in script_text
     assert "MCP_CDK_ASSET_DIR" in script_text
     assert "MCP_PIPELINE_CONFIG_PATH" in script_text
+    assert 'export RELEASE_TAG="$release_tag"' in script_text
     assert "gh release download" in script_text
     assert "uv sync --locked --project ocr-service" in script_text
     assert "npm ci --prefix infra/cdk" in script_text

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -159,6 +159,7 @@ main() {
   done
 
   [[ "$release_tag" == "$confirm_release_tag" ]] || die "release_tag confirmation does not match"
+  export RELEASE_TAG="$release_tag"
 
   ROOT="$(resolve_repo_root)"
   CONFIG_PATH="$ROOT/infra/pipeline-config.json"


### PR DESCRIPTION
## 变更摘要

这是一条在 deploy 验证中补上的小修复。`scripts/prod-deploy.sh` 之前把 `release_tag` 只保存在局部变量里，但后面的 release asset 构建函数读取的是环境变量 `RELEASE_TAG`，会导致脚本在源码打包路径下中途失败。现在把 `release_tag` 统一导出为 `RELEASE_TAG`，并补充测试，确保后续不会再掉回这个作用域问题。

## 关联 Issue

- 关联 issue：无
- 关闭关系：不适用
- 如果没有关联 issue，请说明原因：这是在上一个 PR 合并后、deploy 验证过程中补到的 follow-up 修复

## 变更类型

- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [ ] 配置
- [x] 测试
- [ ] 维护 / 清理

## 影响范围

- 受影响的目录：`scripts/`、`ocr-service/tools/ci/tests/`
- 受影响的模块 / 服务：生产部署脚本
- 受影响的 workflow：无
- 受影响的脚本 / 任务：`scripts/prod-deploy.sh`
- 受影响的数据结构 / 配置：无
- 是否影响默认 PR 门禁：轻微影响，补充脚本回归测试
- 是否影响部署 / 回滚：无额外变化

## 详细说明

### 1. 主要改动

- 在脚本入口处导出 `RELEASE_TAG`，让后续 helper 函数可以稳定读取。
- 在部署脚本测试中补上 `export RELEASE_TAG="$release_tag"` 的断言。

### 2. 设计选择

- 为什么采用当前方案：直接把局部输入提升成环境变量，最小改动且和脚本中现有 helper 的读取方式一致。
- 备选方案是什么：改写 helper 让它们接收更多位置参数。
- 为什么没有选择备选方案：会增加脚本复杂度，没有必要。

### 3. 兼容性

- 是否向后兼容：是。
- 是否需要迁移：不需要。
- 是否需要重建索引 / 重新部署 / 重新生成产物：不需要。
- 是否引入新环境变量 / 新配置项：没有。

### 4. 代码 / 文件清单

- 新增文件：无
- 修改文件：`scripts/prod-deploy.sh`、`ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py`
- 删除文件：无
- 重命名文件：无

## 验证

### 本地验证

- 执行的命令：`bash -n scripts/prod-deploy.sh`
- 命令输出结论：通过
- 执行的命令：`uv run --project ocr-service python -m pytest -q ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py ocr-service/tools/ci/tests/ci/test_validate_workflows.py`
- 命令输出结论：通过
- 执行的命令：`bash scripts/prod-deploy.sh --release-tag main --confirm-release-tag main`
- 命令输出结论：脚本成功走到 AWS 凭证检查，随后因为本地环境没有 AWS 证书而停止

### 自动化验证

- [x] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [x] 构建检查
- [x] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：脚本语法、pytest、workflow inventory、ruff
- 失败项：无
- 未执行项及原因：真实 AWS/CDK 部署未在本地执行

## 风险与回滚

- 主要风险：无明显新增风险。
- 风险缓解方式：增加了回归测试。
- 回滚方式：回退这一条小修复即可。
- 回滚后遗留影响：deploy 脚本会回到之前的作用域错误。
- 是否需要灰度：不需要。

## 对业务 / 运维的影响

- 是否影响线上行为：不改变业务行为。
- 是否影响部署流程：修复 deploy 脚本的本地路径和变量作用域。
- 是否影响监控 / 告警：不影响。
- 是否影响成本 / 性能：不影响。
- 是否影响运维手册：不需要。

## 截图 / 录屏 / 示例

- 截图：无
- 录屏：无
- 示例输入：`bash scripts/prod-deploy.sh --release-tag main --confirm-release-tag main`
- 示例输出：脚本完成 release asset 生成并进入 AWS 凭证检查阶段

## 待确认事项

- [ ] 无

## Reviewer 关注点

- 请重点检查：`RELEASE_TAG` 是否在脚本所有 helper 中都能读取到
- 请重点验证：deploy 脚本的源码打包路径是否仍能跑通

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本裸写了关联说明，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 若涉及代码变更，已补齐测试说明
