### PR TITLE
fix: call prod deploy script from repo root

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -86,4 +86,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           CONFIRM_RELEASE_TAG: ${{ inputs.confirm_release_tag }}
-        run: bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag "$RELEASE_TAG" --confirm-release-tag "$CONFIRM_RELEASE_TAG"
+        run: bash scripts/prod-deploy.sh --release-tag "$RELEASE_TAG" --confirm-release-tag "$CONFIRM_RELEASE_TAG"

--- a/ocr-service/tools/ci/tests/ci/test_validate_workflows.py
+++ b/ocr-service/tools/ci/tests/ci/test_validate_workflows.py
@@ -97,7 +97,7 @@ def test_prod_deploy_is_reduced_to_a_single_script_entrypoint() -> None:
     text = workflow_path.read_text(encoding="utf-8")
 
     assert "name: Prod Deploy" in text
-    assert "bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag" in text
+    assert "bash scripts/prod-deploy.sh --release-tag" in text
     assert "aws-actions/configure-aws-credentials@v6" in text
     assert "MCP_CDK_ASSET_DIR:" not in text
     assert "Validate release asset manifest" not in text

--- a/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -15,7 +15,7 @@ def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     script_text = script_path.read_text(encoding="utf-8")
 
     assert "name: Prod Deploy" in workflow_text
-    assert "bash serverless-kb-mcp/scripts/prod-deploy.sh --release-tag" in workflow_text
+    assert "bash scripts/prod-deploy.sh --release-tag" in workflow_text
     assert "aws-actions/configure-aws-credentials@v6" in workflow_text
     assert "MCP_CDK_ASSET_DIR:" not in workflow_text
     assert "Validate release asset manifest" not in workflow_text

--- a/ocr-service/tools/ci/validate_workflows.py
+++ b/ocr-service/tools/ci/validate_workflows.py
@@ -405,8 +405,8 @@ def _assert_prod_deploy_alignment(errors: list[str]) -> None:
     CN: 确保 prod deploy 收敛为单一脚本入口和 AWS 凭证配置。"""
     prod_text = (REPO_ROOT / ".github" / "workflows" / "prod-deploy.yml").read_text(encoding="utf-8")
 
-    if "bash serverless-kb-mcp/scripts/prod-deploy.sh" not in prod_text:
-        errors.append(".github/workflows/prod-deploy.yml must call serverless-kb-mcp/scripts/prod-deploy.sh")
+    if "bash scripts/prod-deploy.sh" not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must call scripts/prod-deploy.sh")
     for legacy_marker in (
         "Set up runtime",
         "Resolve packaged release assets",


### PR DESCRIPTION
修正 Prod Deploy workflow 里调用入口脚本的路径。workflow 在  仓库根目录 checkout 后，应执行 ，而不是带上不存在的  前缀。同步更新 workflow 校验与测试断言，避免回归。