### PR TITLE
fix: support prod deploy from submodule checkout

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -86,4 +86,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           CONFIRM_RELEASE_TAG: ${{ inputs.confirm_release_tag }}
-        run: bash scripts/prod-deploy.sh --release-tag "$RELEASE_TAG" --confirm-release-tag "$CONFIRM_RELEASE_TAG"
+        run: |
+          set -euo pipefail
+
+          ENTRYPOINT="scripts/prod-deploy.sh"
+          if [ ! -f "$ENTRYPOINT" ] && [ -f "serverless-kb-mcp/scripts/prod-deploy.sh" ]; then
+            ENTRYPOINT="serverless-kb-mcp/scripts/prod-deploy.sh"
+          fi
+
+          if [ ! -f "$ENTRYPOINT" ]; then
+            echo "::error::prod deploy script not found at scripts/prod-deploy.sh or serverless-kb-mcp/scripts/prod-deploy.sh"
+            exit 1
+          fi
+
+          bash "$ENTRYPOINT" --release-tag "$RELEASE_TAG" --confirm-release-tag "$CONFIRM_RELEASE_TAG"

--- a/ocr-service/tools/ci/tests/ci/test_validate_workflows.py
+++ b/ocr-service/tools/ci/tests/ci/test_validate_workflows.py
@@ -97,7 +97,9 @@ def test_prod_deploy_is_reduced_to_a_single_script_entrypoint() -> None:
     text = workflow_path.read_text(encoding="utf-8")
 
     assert "name: Prod Deploy" in text
-    assert "bash scripts/prod-deploy.sh --release-tag" in text
+    assert 'ENTRYPOINT="scripts/prod-deploy.sh"' in text
+    assert "serverless-kb-mcp/scripts/prod-deploy.sh" in text
+    assert 'bash "$ENTRYPOINT" --release-tag' in text
     assert "aws-actions/configure-aws-credentials@v6" in text
     assert "MCP_CDK_ASSET_DIR:" not in text
     assert "Validate release asset manifest" not in text

--- a/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -15,7 +15,9 @@ def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     script_text = script_path.read_text(encoding="utf-8")
 
     assert "name: Prod Deploy" in workflow_text
-    assert "bash scripts/prod-deploy.sh --release-tag" in workflow_text
+    assert 'ENTRYPOINT="scripts/prod-deploy.sh"' in workflow_text
+    assert "serverless-kb-mcp/scripts/prod-deploy.sh" in workflow_text
+    assert 'bash "$ENTRYPOINT" --release-tag' in workflow_text
     assert "aws-actions/configure-aws-credentials@v6" in workflow_text
     assert "MCP_CDK_ASSET_DIR:" not in workflow_text
     assert "Validate release asset manifest" not in workflow_text

--- a/ocr-service/tools/ci/validate_workflows.py
+++ b/ocr-service/tools/ci/validate_workflows.py
@@ -405,8 +405,12 @@ def _assert_prod_deploy_alignment(errors: list[str]) -> None:
     CN: 确保 prod deploy 收敛为单一脚本入口和 AWS 凭证配置。"""
     prod_text = (REPO_ROOT / ".github" / "workflows" / "prod-deploy.yml").read_text(encoding="utf-8")
 
-    if "bash scripts/prod-deploy.sh" not in prod_text:
-        errors.append(".github/workflows/prod-deploy.yml must call scripts/prod-deploy.sh")
+    if 'ENTRYPOINT="scripts/prod-deploy.sh"' not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must resolve scripts/prod-deploy.sh as the primary entrypoint")
+    if "serverless-kb-mcp/scripts/prod-deploy.sh" not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must fall back to serverless-kb-mcp/scripts/prod-deploy.sh")
+    if 'bash "$ENTRYPOINT" --release-tag' not in prod_text:
+        errors.append(".github/workflows/prod-deploy.yml must invoke the resolved prod deploy entrypoint")
     for legacy_marker in (
         "Set up runtime",
         "Resolve packaged release assets",


### PR DESCRIPTION
Prod Deploy 的 reusable workflow 需要同时兼容两种 checkout 形态：\n- serverless-kb-mcp 仓库直接运行时使用 scripts/prod-deploy.sh\n- serverless-kb-mcp-self-hosted 通过子模块调用时使用 serverless-kb-mcp/scripts/prod-deploy.sh\n\n这次改成运行时自动探测入口路径，并同步修正 workflow 校验与测试断言。