### PR TITLE
fix: build extract layer with Lambda-compatible native deps

### DIFF
--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_artifact_scripts.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_artifact_scripts.py
@@ -68,6 +68,7 @@ def test_layer_dependencies_keep_pydantic_and_requests_out_of_core() -> None:
     assert "pydantic>=2.11.3" not in module.LAYER_DEPENDENCIES["core"]
     assert "pydantic>=2.11.3" in module.LAYER_DEPENDENCIES["extract"]
     assert "requests>=2.32.0" in module.LAYER_DEPENDENCIES["extract"]
+    assert "tiktoken>=0.7.0" not in module.LAYER_DEPENDENCIES["extract"]
 
 
 def test_build_s3_key_uses_prefix_when_present() -> None:
@@ -185,6 +186,7 @@ def test_build_layer_artifacts_builds_selected_layers(tmp_path, capsys, monkeypa
     assert (output_dir / "serverless-kb-mcp_core_layer.zip").exists()
     assert (output_dir / "serverless-kb-mcp_extract_layer.zip").exists()
     assert len(calls) == 2
+    assert all("--python-version" in call and "--python-platform" in call for call in calls)
     assert "serverless-kb-mcp_core_layer.zip" in captured.out
     assert "serverless-kb-mcp_extract_layer.zip" in captured.out
 

--- a/ocr-service/tools/packaging/serverless_mcp/build_layer_artifacts.py
+++ b/ocr-service/tools/packaging/serverless_mcp/build_layer_artifacts.py
@@ -30,6 +30,10 @@ if str(SCRIPT_ROOT) not in sys.path:
 from layer_artifacts import LAYER_DEPENDENCIES, build_layer_zip_name, parse_layer_keys
 
 
+LAMBDA_PYTHON_VERSION = "3.14"
+LAMBDA_PYTHON_PLATFORM = "x86_64-manylinux2014"
+
+
 @dataclass(slots=True)
 class _SharedStaging:
     """EN: Cache entry that pairs a TemporaryDirectory with its staging path.
@@ -130,6 +134,10 @@ def _ensure_layer_staging(*, dependencies: tuple[str, ...], label: str) -> Path:
         "pip",
         "install",
         "--upgrade",
+        "--python-version",
+        LAMBDA_PYTHON_VERSION,
+        "--python-platform",
+        LAMBDA_PYTHON_PLATFORM,
         *dependencies,
         "--target",
         str(staging),

--- a/ocr-service/tools/packaging/serverless_mcp/layer_artifacts.py
+++ b/ocr-service/tools/packaging/serverless_mcp/layer_artifacts.py
@@ -26,7 +26,6 @@ LAYER_DEPENDENCIES: dict[str, list[str]] = {
         "python-docx>=1.1.2",
         "python-pptx>=1.0.2",
         "pydantic>=2.11.3",
-        "tiktoken>=0.7.0",
         "requests>=2.32.0",
     ],
     "embedding": [


### PR DESCRIPTION
## 变更摘要

Closes #90

这次修复针对 `extract` Lambda 初始化时导入 `lxml.etree` 失败的问题。根因不是业务入口 `lambda_function.py`，而是 layer 打包产物依赖了宿主机平台的 native wheel，导致线上环境里的 `lxml` 扩展不可用。

我把 `build_layer_artifacts.py` 改成显式按 Lambda 目标平台安装依赖，并把 `extract` 层里可选的 `tiktoken` 移出运行时 layer，避免 layer 构建回落到 Rust 源码编译路径。修复后，layer zip 里能正确出现 `python/lxml/etree.cpython-314-x86_64-linux-gnu.so`。

没有改动业务抽取逻辑，也没有改动 CDK 资源拓扑。对外可见结果是 `extract_*` Lambda 能正常初始化，PrepareJob 不会再因为这一层依赖导入错误直接失败。

## 关联 Issue

- 关联 issue：#90
- 关闭关系：Closes #90
- 如果没有关联 issue，请说明原因：不适用

## 变更类型

- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [ ] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围

- 受影响的目录：`ocr-service/tools/packaging/serverless_mcp/`、`ocr-service/ocr-pipeline/tests/unit/serverless_mcp/`
- 受影响的模块 / 服务：Lambda layer 打包脚本、extract layer 依赖集
- 受影响的 workflow：无直接 workflow 变更，但 `Package Release` / `Prod Deploy` 会使用新的 layer 产物
- 受影响的脚本 / 任务：`build_layer_artifacts.py`
- 受影响的数据结构 / 配置：`LAYER_DEPENDENCIES['extract']`
- 是否影响默认 PR 门禁：是，相关单测和全量 pytest 会覆盖
- 是否影响部署 / 回滚：会影响后续打包出的 layer zip；回滚只需恢复上一版 layer 产物或回退该提交

## 详细说明

### 1. 主要改动

- 改动点 1：为 layer 构建显式指定 Lambda 目标平台 wheel 解析参数。
- 改动点 2：从 `extract` layer 依赖中移除可选的 `tiktoken`，避免 layer 构建被 Rust 源码编译阻塞。
- 改动点 3：补充测试，锁定 layer 构建命令和依赖清单。

### 2. 设计选择

- 为什么采用当前方案：`lxml` 必须按 Lambda 目标平台构建，而 `tiktoken` 在当前目标上没有稳定 wheel，保留它会把 layer 构建拖进不可控的本地源码编译路径。
- 备选方案是什么：继续把 `tiktoken` 留在 layer 里，并为构建环境补 Rust/toolchain。
- 为什么没有选择备选方案：这会增加 release / deploy 的环境复杂度，也和当前“可重复、可在 GitHub Actions 官方 runner 上完成”的交付要求不一致。

### 3. 兼容性

- 是否向后兼容：对运行时行为兼容，`tiktoken` 本身是可选加载，缺失后会回落到字符数启发式。
- 是否需要迁移：不需要数据迁移。
- 是否需要重建索引 / 重新部署 / 重新生成产物：需要重新打包并重新部署 layer 产物。
- 是否引入新环境变量 / 新配置项：没有。

### 4. 代码 / 文件清单

- 新增文件：无
- 修改文件：`ocr-service/tools/packaging/serverless_mcp/build_layer_artifacts.py`、`ocr-service/tools/packaging/serverless_mcp/layer_artifacts.py`、`ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_artifact_scripts.py`
- 删除文件：无
- 重命名文件：无

## 验证

### 本地验证

- 执行的命令：`uv run --project ocr-service python -m pytest -q`
- 命令输出结论：`320 passed, 2 skipped`
- 相关截图 / 日志 / 链接：已在本地验证 layer zip 包含 `python/lxml/etree.cpython-314-x86_64-linux-gnu.so`

### 自动化验证

- [x] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [ ] 构建检查
- [ ] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：全量 `pytest`、相关打包脚本单测、实际 layer 构建检查
- 失败项：无
- 未执行项及原因：未单独跑 GitHub Actions workflow，因为本地 `pytest` 已覆盖当前改动范围

## 风险与回滚

- 主要风险：移除 `tiktoken` 后，少量 token 计数路径会回落到字符数启发式；但这一路径本身已设计为可选。
- 风险缓解方式：保留 `tiktoken` 不可用时的 fallback，并通过测试锁定打包行为。
- 回滚方式：回退该提交并重新生成 layer 产物。
- 回滚后遗留影响：需要重新部署一次 layer 版本。
- 是否需要灰度：不强制，但建议先在非生产环境验证生成的 layer zip。

## 对业务 / 运维的影响

- 是否影响线上行为：仅修复初始化失败，不改变抽取主流程语义。
- 是否影响部署流程：会让 layer 构建更稳定，减少本机平台污染。
- 是否影响监控 / 告警：间接降低 `Runtime.ImportModuleError` 类告警。
- 是否影响成本 / 性能：无明显额外成本。
- 是否影响运维手册：不需要额外改动。

## 截图 / 录屏 / 示例

- 截图：无
- 录屏：无
- 示例输入：`应急领域市场、渠道与利润分析v0.2.pdf`
- 示例输出：`extract` Lambda 能正常初始化，`lxml.etree` 可导入

## 待确认事项

- [ ] 待确认 1
- [ ] 待确认 2
- [ ] 待确认 3

## Reviewer 关注点

- 请重点检查：`build_layer_artifacts.py` 的平台约束是否足以保证 Lambda 兼容性
- 请重点验证：`extract` layer 里是否仍存在会触发本机源码编译的依赖
- 请重点确认：`tiktoken` 从 layer 中移除后，`extract/policy.py` 的 fallback 路径是否符合预期

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出