### PR TITLE
新增整体架构 skill 并同步生成物

### DIFF
--- a/.agents/skills/serverless-kb-architecture/SKILL.md
+++ b/.agents/skills/serverless-kb-architecture/SKILL.md
@@ -1,0 +1,104 @@
+---
+description: 适用于本仓库整体 serverless 文档检索系统的架构设计、边界收敛、重构、测试和文档同步，覆盖 ingestion、query、storage、infra 和 skill 之间的协同。
+name: serverless-kb-architecture
+---
+
+
+# 仓库整体架构
+
+当任务涉及本仓库的整体代码架构、模块边界、运行时职责、目录落位、跨层重构、测试策略或文档同步时，优先使用这个 skill。
+
+## 适用范围
+
+- `ocr-service/ocr-pipeline/src/serverless_mcp/` 下的所有业务模块
+- `ocr-service/infra/` 的资源拓扑和部署命名
+- `docs/` 中关于运行时、部署、验证、排障和交付流程的文档
+- `ai/skills-src/` 中与本仓库架构相关的其他 skill
+
+## 当前整体架构
+
+```text
+source bucket
+-> S3 Event Notification
+-> SQS ingest queue
+-> Ingest Lambda
+-> Step Functions Standard
+   -> extract workflow lambdas
+   -> manifest bucket
+   -> SQS embed queue
+-> Embed Lambda
+-> Embedding provider
+-> S3 Vectors
+-> SQS DLQ
+-> Query Service / MCP Query Lambda
+-> metadata store / manifest store / object storage
+```
+
+本仓库不是单体应用。摄取链路、查询链路、存储层、部署层和 skill 层都应分别收敛，不能因为某一处入口改动就把职责重新压回一个大 Lambda 或一个大目录。
+
+## 核心边界
+
+### 摄取链路
+
+- 负责 S3 版本事件、入队、OCR 编排、Step Functions 状态推进、manifest 生成和 embedding 投递。
+- 对象主身份必须围绕 `version_id` 管理，不要只按路径或文件名建模。
+- `object_state` 负责主状态推进，`manifest_index` 负责版本级 chunk 反查，`embedding_projection_state` 负责按 profile 隔离的投影状态。
+
+### 查询链路
+
+- 负责 query-time 的检索、摘要、版本查询和状态查询。
+- 远程 MCP 入口只承载查询侧能力，不承载 OCR、Step Functions 或 embedding worker。
+- 工具应该对应业务能力，不应该暴露 embedding、vector、worker 或底层协议实现细节。
+
+### 存储层
+
+- `manifest bucket` 用于保存结构化提取结果、切片资产和可回放材料。
+- `S3 Vectors` 只承载同一 embedding profile 的向量，不混写不同模型、维度或 provider。
+- `DynamoDB` 用于幂等、版本隔离、状态推进、失败补偿和回查，不要把所有职责压成一张通用表。
+
+### 基础设施
+
+- `infra/` 只表达资源拓扑、命名、环境变量和部署入口。
+- 任何资源、权限、流程或命名变化，都必须回写到 `docs/` 和相关 skill。
+- 默认验证不能依赖真实云账号，优先使用本地仿真、service containers 和固定样本。
+
+## 推荐配套 skill
+
+这个 skill 管的是总纲。具体子域任务应切到对应 skill：
+
+- `versioned-s3-ingest`：S3 versioning、事件、幂等、object_state、版本推进
+- `durable-s3-embed-pipeline`：OCR、Step Functions、抽取编排、embed worker
+- `vector-manifest-storage`：manifest、projection、S3 Vectors、状态存储
+- `remote-mcp-query-gateway`：远程 MCP 查询入口和协议层收敛
+- `project-delivery-guardrails`：跨模块改动前的架构梳理和落位
+- `architecture-reset-refactor`：需要彻底重排目录和删除旧抽象时
+
+如果一个任务同时涉及多个子域，先用这个 skill 理清总边界，再按子域 skill 分段处理，不要把所有规则混在一个答复里。
+
+## 实施顺序
+
+1. 先判断需求属于摄取、查询、存储、infra 还是文档层。
+2. 盘点现有模块职责和依赖方向，找出重复抽象和错误落位。
+3. 先给出目标目录和文件边界，再开始改代码。
+4. 相关测试、文档、skill 和部署说明一起收敛。
+5. 修改 Python 代码后，必须跑仓库要求的全量测试。
+6. 修改 skill 后，必须运行 `python ai/scripts/sync-ai.py`，同步到 `.agents/skills/` 和 `.claude/skills/`。
+
+## 不要做的事
+
+- 不要把查询入口、摄取编排和 embedding worker 合并成一个大入口。
+- 不要把协议层、业务层和存储层写在同一个模块里。
+- 不要为了兼容旧结构，长期保留明显多余的 wrapper、转发层和别名层。
+- 不要把本地替代实现当成云服务语义完全等价的实现。
+- 不要为了看起来统一，牺牲清晰的职责边界。
+
+## 验证要求
+
+- 先验证结构，再验证实现。
+- 修改协议、入口或边界时，补齐生命周期测试和回归测试。
+- 修改 infra 或流程时，同步更新文档和相关 skill。
+- 如果需要提交 PR，正文前部必须写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，并按模板完整填写。
+
+## 备注
+
+这个 skill 的目标是让人一眼看清仓库当前整体架构，而不是只记住某一个入口或某一个子系统。

--- a/.claude/skills/serverless-kb-architecture/SKILL.md
+++ b/.claude/skills/serverless-kb-architecture/SKILL.md
@@ -1,0 +1,104 @@
+---
+description: 适用于本仓库整体 serverless 文档检索系统的架构设计、边界收敛、重构、测试和文档同步，覆盖 ingestion、query、storage、infra 和 skill 之间的协同。
+name: serverless-kb-architecture
+---
+
+
+# 仓库整体架构
+
+当任务涉及本仓库的整体代码架构、模块边界、运行时职责、目录落位、跨层重构、测试策略或文档同步时，优先使用这个 skill。
+
+## 适用范围
+
+- `ocr-service/ocr-pipeline/src/serverless_mcp/` 下的所有业务模块
+- `ocr-service/infra/` 的资源拓扑和部署命名
+- `docs/` 中关于运行时、部署、验证、排障和交付流程的文档
+- `ai/skills-src/` 中与本仓库架构相关的其他 skill
+
+## 当前整体架构
+
+```text
+source bucket
+-> S3 Event Notification
+-> SQS ingest queue
+-> Ingest Lambda
+-> Step Functions Standard
+   -> extract workflow lambdas
+   -> manifest bucket
+   -> SQS embed queue
+-> Embed Lambda
+-> Embedding provider
+-> S3 Vectors
+-> SQS DLQ
+-> Query Service / MCP Query Lambda
+-> metadata store / manifest store / object storage
+```
+
+本仓库不是单体应用。摄取链路、查询链路、存储层、部署层和 skill 层都应分别收敛，不能因为某一处入口改动就把职责重新压回一个大 Lambda 或一个大目录。
+
+## 核心边界
+
+### 摄取链路
+
+- 负责 S3 版本事件、入队、OCR 编排、Step Functions 状态推进、manifest 生成和 embedding 投递。
+- 对象主身份必须围绕 `version_id` 管理，不要只按路径或文件名建模。
+- `object_state` 负责主状态推进，`manifest_index` 负责版本级 chunk 反查，`embedding_projection_state` 负责按 profile 隔离的投影状态。
+
+### 查询链路
+
+- 负责 query-time 的检索、摘要、版本查询和状态查询。
+- 远程 MCP 入口只承载查询侧能力，不承载 OCR、Step Functions 或 embedding worker。
+- 工具应该对应业务能力，不应该暴露 embedding、vector、worker 或底层协议实现细节。
+
+### 存储层
+
+- `manifest bucket` 用于保存结构化提取结果、切片资产和可回放材料。
+- `S3 Vectors` 只承载同一 embedding profile 的向量，不混写不同模型、维度或 provider。
+- `DynamoDB` 用于幂等、版本隔离、状态推进、失败补偿和回查，不要把所有职责压成一张通用表。
+
+### 基础设施
+
+- `infra/` 只表达资源拓扑、命名、环境变量和部署入口。
+- 任何资源、权限、流程或命名变化，都必须回写到 `docs/` 和相关 skill。
+- 默认验证不能依赖真实云账号，优先使用本地仿真、service containers 和固定样本。
+
+## 推荐配套 skill
+
+这个 skill 管的是总纲。具体子域任务应切到对应 skill：
+
+- `versioned-s3-ingest`：S3 versioning、事件、幂等、object_state、版本推进
+- `durable-s3-embed-pipeline`：OCR、Step Functions、抽取编排、embed worker
+- `vector-manifest-storage`：manifest、projection、S3 Vectors、状态存储
+- `remote-mcp-query-gateway`：远程 MCP 查询入口和协议层收敛
+- `project-delivery-guardrails`：跨模块改动前的架构梳理和落位
+- `architecture-reset-refactor`：需要彻底重排目录和删除旧抽象时
+
+如果一个任务同时涉及多个子域，先用这个 skill 理清总边界，再按子域 skill 分段处理，不要把所有规则混在一个答复里。
+
+## 实施顺序
+
+1. 先判断需求属于摄取、查询、存储、infra 还是文档层。
+2. 盘点现有模块职责和依赖方向，找出重复抽象和错误落位。
+3. 先给出目标目录和文件边界，再开始改代码。
+4. 相关测试、文档、skill 和部署说明一起收敛。
+5. 修改 Python 代码后，必须跑仓库要求的全量测试。
+6. 修改 skill 后，必须运行 `python ai/scripts/sync-ai.py`，同步到 `.agents/skills/` 和 `.claude/skills/`。
+
+## 不要做的事
+
+- 不要把查询入口、摄取编排和 embedding worker 合并成一个大入口。
+- 不要把协议层、业务层和存储层写在同一个模块里。
+- 不要为了兼容旧结构，长期保留明显多余的 wrapper、转发层和别名层。
+- 不要把本地替代实现当成云服务语义完全等价的实现。
+- 不要为了看起来统一，牺牲清晰的职责边界。
+
+## 验证要求
+
+- 先验证结构，再验证实现。
+- 修改协议、入口或边界时，补齐生命周期测试和回归测试。
+- 修改 infra 或流程时，同步更新文档和相关 skill。
+- 如果需要提交 PR，正文前部必须写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，并按模板完整填写。
+
+## 备注
+
+这个 skill 的目标是让人一眼看清仓库当前整体架构，而不是只记住某一个入口或某一个子系统。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@
 - architecture-reset-refactor
   - [ai/skills-src/architecture-reset-refactor/SKILL.md](ai/skills-src/architecture-reset-refactor/SKILL.md)
   - 适用于用户明确允许不考虑旧兼容性时，先审视当前架构，再按当前最优结构做大规模重构与目录重排。
+- serverless-kb-architecture
+  - [ai/skills-src/serverless-kb-architecture/SKILL.md](ai/skills-src/serverless-kb-architecture/SKILL.md)
+  - 适用于本仓库整体 serverless 文档检索系统的架构设计、边界收敛、重构、测试和文档同步，覆盖 ingestion、query、storage、infra 和 skill 之间的协同。
 - durable-s3-embed-pipeline
   - [ai/skills-src/durable-s3-embed-pipeline/SKILL.md](ai/skills-src/durable-s3-embed-pipeline/SKILL.md)
   - 适用于最小可用的 `S3 Event Notification -> SQS -> Ingest Lambda -> Step Functions Standard -> SQS -> Embed Lambda` 架构设计、资源拆分、职责边界和带序号时序图说明。

--- a/ai/skills-src/serverless-kb-architecture/SKILL.md
+++ b/ai/skills-src/serverless-kb-architecture/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: serverless-kb-architecture
+description: 适用于本仓库整体 serverless 文档检索系统的架构设计、边界收敛、重构、测试和文档同步，覆盖 ingestion、query、storage、infra 和 skill 之间的协同。
+---
+
+# 仓库整体架构
+
+当任务涉及本仓库的整体代码架构、模块边界、运行时职责、目录落位、跨层重构、测试策略或文档同步时，优先使用这个 skill。
+
+## 适用范围
+
+- `ocr-service/ocr-pipeline/src/serverless_mcp/` 下的所有业务模块
+- `ocr-service/infra/` 的资源拓扑和部署命名
+- `docs/` 中关于运行时、部署、验证、排障和交付流程的文档
+- `ai/skills-src/` 中与本仓库架构相关的其他 skill
+
+## 当前整体架构
+
+```text
+source bucket
+-> S3 Event Notification
+-> SQS ingest queue
+-> Ingest Lambda
+-> Step Functions Standard
+   -> extract workflow lambdas
+   -> manifest bucket
+   -> SQS embed queue
+-> Embed Lambda
+-> Embedding provider
+-> S3 Vectors
+-> SQS DLQ
+-> Query Service / MCP Query Lambda
+-> metadata store / manifest store / object storage
+```
+
+本仓库不是单体应用。摄取链路、查询链路、存储层、部署层和 skill 层都应分别收敛，不能因为某一处入口改动就把职责重新压回一个大 Lambda 或一个大目录。
+
+## 核心边界
+
+### 摄取链路
+
+- 负责 S3 版本事件、入队、OCR 编排、Step Functions 状态推进、manifest 生成和 embedding 投递。
+- 对象主身份必须围绕 `version_id` 管理，不要只按路径或文件名建模。
+- `object_state` 负责主状态推进，`manifest_index` 负责版本级 chunk 反查，`embedding_projection_state` 负责按 profile 隔离的投影状态。
+
+### 查询链路
+
+- 负责 query-time 的检索、摘要、版本查询和状态查询。
+- 远程 MCP 入口只承载查询侧能力，不承载 OCR、Step Functions 或 embedding worker。
+- 工具应该对应业务能力，不应该暴露 embedding、vector、worker 或底层协议实现细节。
+
+### 存储层
+
+- `manifest bucket` 用于保存结构化提取结果、切片资产和可回放材料。
+- `S3 Vectors` 只承载同一 embedding profile 的向量，不混写不同模型、维度或 provider。
+- `DynamoDB` 用于幂等、版本隔离、状态推进、失败补偿和回查，不要把所有职责压成一张通用表。
+
+### 基础设施
+
+- `infra/` 只表达资源拓扑、命名、环境变量和部署入口。
+- 任何资源、权限、流程或命名变化，都必须回写到 `docs/` 和相关 skill。
+- 默认验证不能依赖真实云账号，优先使用本地仿真、service containers 和固定样本。
+
+## 推荐配套 skill
+
+这个 skill 管的是总纲。具体子域任务应切到对应 skill：
+
+- `versioned-s3-ingest`：S3 versioning、事件、幂等、object_state、版本推进
+- `durable-s3-embed-pipeline`：OCR、Step Functions、抽取编排、embed worker
+- `vector-manifest-storage`：manifest、projection、S3 Vectors、状态存储
+- `remote-mcp-query-gateway`：远程 MCP 查询入口和协议层收敛
+- `project-delivery-guardrails`：跨模块改动前的架构梳理和落位
+- `architecture-reset-refactor`：需要彻底重排目录和删除旧抽象时
+
+如果一个任务同时涉及多个子域，先用这个 skill 理清总边界，再按子域 skill 分段处理，不要把所有规则混在一个答复里。
+
+## 实施顺序
+
+1. 先判断需求属于摄取、查询、存储、infra 还是文档层。
+2. 盘点现有模块职责和依赖方向，找出重复抽象和错误落位。
+3. 先给出目标目录和文件边界，再开始改代码。
+4. 相关测试、文档、skill 和部署说明一起收敛。
+5. 修改 Python 代码后，必须跑仓库要求的全量测试。
+6. 修改 skill 后，必须运行 `python ai/scripts/sync-ai.py`，同步到 `.agents/skills/` 和 `.claude/skills/`。
+
+## 不要做的事
+
+- 不要把查询入口、摄取编排和 embedding worker 合并成一个大入口。
+- 不要把协议层、业务层和存储层写在同一个模块里。
+- 不要为了兼容旧结构，长期保留明显多余的 wrapper、转发层和别名层。
+- 不要把本地替代实现当成云服务语义完全等价的实现。
+- 不要为了看起来统一，牺牲清晰的职责边界。
+
+## 验证要求
+
+- 先验证结构，再验证实现。
+- 修改协议、入口或边界时，补齐生命周期测试和回归测试。
+- 修改 infra 或流程时，同步更新文档和相关 skill。
+- 如果需要提交 PR，正文前部必须写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，并按模板完整填写。
+
+## 备注
+
+这个 skill 的目标是让人一眼看清仓库当前整体架构，而不是只记住某一个入口或某一个子系统。


### PR DESCRIPTION
## 变更摘要

本 PR 新增 `serverless-kb-architecture` skill，把本仓库当前整体 serverless 文档检索系统的架构沉淀为统一参考，而不是只描述远程 MCP 查询入口。

这个 skill 覆盖 ingestion、query、storage、infra、tests 和相关 skill 之间的协同边界，重点强调当前仓库是“多段式 serverless workspace”，而不是单一入口 Lambda。它明确描述了摄取链路 `source bucket -> S3 Event Notification -> SQS ingest queue -> Ingest Lambda -> Step Functions Standard -> extract workflow lambdas -> manifest bucket -> SQS embed queue -> Embed Lambda -> DLQ`，以及查询链路 `API Gateway /mcp -> MCP Query Lambda -> query services -> storage` 的分层方式。

同时，本 PR 将该 skill 同步到 `.agents/skills/` 和 `.claude/skills/`，并把它挂到 `AGENTS.md` 的技能导航中，避免后续同类任务只能在 MCP 专项 skill 里找入口。

## 关联 Issue

- 关联 issue：#92（相关架构同步）
- 关闭关系：无
- 跨仓库引用：无
- 如果没有关联 issue，请说明原因：这是对当前整体架构的知识沉淀与技能同步，不对应新的功能修复或缺陷关闭。

## 变更类型

- [ ] 缺陷修复
- [ ] 新功能
- [x] 文档
- [x] 维护 / 清理
- [x] 配置
- [ ] 测试
- [ ] CI / workflow
- [ ] 安全加固

## 影响范围

- 受影响的目录：`ai/skills-src/`、`.agents/skills/`、`.claude/skills/`、`AGENTS.md`
- 受影响的模块 / 服务：无运行时模块变更
- 受影响的 workflow：无
- 受影响的脚本 / 任务：`python ai/scripts/sync-ai.py`
- 受影响的数据结构 / 配置：无
- 是否影响默认 PR 门禁：不影响
- 是否影响部署 / 回滚：不影响部署；回滚只需撤回 skill 与导航变更

## 详细说明

### 1. 为什么要新增这个 skill

- 当前仓库的架构已经不再适合用单一 MCP 专项 skill 解释全部内容。
- 本仓库同时存在 ingestion、query、storage、infra 和文档/skill 同步几条主线，任务时常跨多个子域。
- 如果只保留 MCP 专项 skill，后续做整体架构判断时容易漏掉摄取链路、存储分层和部署边界。

### 2. 这个 skill 覆盖了什么

- 仓库整体的 serverless 运行时边界。
- 摄取链路与查询链路的职责分离。
- `object_state`、`manifest_index`、`embedding_projection_state`、`S3 Vectors`、`manifest bucket` 和 `DynamoDB` 的分工。
- 适用本仓库的配套 skill 选择建议。
- 修改代码、文档、infra 和 skill 时的同步顺序。

### 3. 设计选择

- 备选方案是继续把所有架构知识塞进单个 MCP skill。
- 这样做的风险是 skill 会越来越窄，只能解释查询入口，不能解释整个仓库。
- 当前方案把“总纲 skill”和“子域 skill”分开，便于以后继续扩展和维护。

### 4. 代码 / 文件清单

- 新增文件：`ai/skills-src/serverless-kb-architecture/SKILL.md`
- 修改文件：`AGENTS.md`
- 同步生成：`.agents/skills/serverless-kb-architecture/SKILL.md`、`.claude/skills/serverless-kb-architecture/SKILL.md`
- 删除文件：无
- 重命名文件：无

## 验证

### 本地验证

- 执行的命令：`python ai/scripts/sync-ai.py`
- 命令输出结论：成功同步 14 个 skill 到 `.agents/skills/` 和 `.claude/skills/`
- 相关截图 / 日志 / 链接：无

### 自动化验证

- [ ] 单元测试
- [ ] 集成测试
- [ ] 静态检查
- [ ] 构建检查
- [x] 其他：skill 同步脚本

### 验证结果

- 通过项：skill 源文件、生成文件、AGENTS 导航一致性
- 失败项：无
- 未执行项及原因：未跑 Python 全量测试，因为本 PR 只改 skill / 文档，不涉及运行时代码

## 风险与回滚

- 主要风险：skill 过于偏向某一个子域，导致后续任务仍然找不到整体架构入口。
- 风险缓解方式：skill 正文同时覆盖 ingestion、query、storage、infra 和子 skill 协同关系。
- 回滚方式：回退本 PR 的提交即可。
- 回滚后遗留影响：无运行时影响。
- 是否需要灰度：不需要。

## 对业务 / 运维的影响

- 是否影响线上行为：不影响。
- 是否影响部署流程：不影响。
- 是否影响监控 / 告警：不影响。
- 是否影响成本 / 性能：不影响。
- 是否影响运维手册：间接影响，补充了架构参考入口。

## 截图 / 录屏 / 示例

- 截图：无
- 录屏：无
- 示例输入：查看 `serverless-kb-architecture` skill
- 示例输出：一份覆盖整体 serverless 架构的总纲说明

## 待确认事项

- [x] 无
- [ ] 无
- [ ] 无

## Reviewer 关注点

- 请重点确认：这个 skill 是否真的覆盖了仓库整体架构，而不是又退回到 MCP 专项。
- 请重点确认：`AGENTS.md` 里的技能导航是否指向新的总纲 skill。
- 请重点确认：`.agents/skills/` 和 `.claude/skills/` 是否与 source skill 完全一致。

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
