### PR TITLE
Fix MCP gateway protocol and packaging closure

### DIFF
--- a/ocr-service/ocr-pipeline/README.md
+++ b/ocr-service/ocr-pipeline/README.md
@@ -43,6 +43,8 @@
 
 - Lambda wrapper 由 `tools/packaging/serverless_mcp/package_lambda.py` 生成。
 - Lambda wrapper 注册表由 `tools/packaging/serverless_mcp/lambda_wrappers.py` 维护，并作为打包流水线的唯一事实来源。
+- `awslabs.mcp_lambda_handler` 以源码 vendored 方式保留在 `src/awslabs/mcp_lambda_handler/`，`package_lambda.py` 会在暂存产物阶段显式校验它可以被 import。
+- 当前不依赖外部 pip 安装的 `awslabs.mcp_lambda_handler` 轮子，更新时直接替换 vendored 源码并重新同步打包产物。
 - 打包产物名称由仓库名、函数名和目标产物类型共同决定。
 - 运行时导入路径必须始终指向 `serverless_mcp`，不要再引用旧的 `s3vectors_mcp` 目录名，也不要再引用旧的 `mcp.server` 命名空间。
 

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/server.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/server.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from awslabs.mcp_lambda_handler import MCPLambdaHandler
 from awslabs.mcp_lambda_handler.session import NoOpSessionStore
-from mcp.types import LATEST_PROTOCOL_VERSION
 
 from serverless_mcp.mcp_gateway.tools.get_document_excerpt import get_document_excerpt
 from serverless_mcp.mcp_gateway.tools.get_ingestion_status import get_ingestion_status
@@ -19,6 +18,9 @@ from serverless_mcp.mcp_gateway.tools.search_documents import search_documents
 
 SERVER_NAME = "mcp-doc-pipeline"
 SERVER_VERSION = "1.0.0"
+# EN: Mirror the vendored handler's initialize response protocolVersion.
+# CN: 该常量必须与 vendored handler 的 initialize 响应 protocolVersion 保持一致。
+MCP_PROTOCOL_VERSION = "2024-11-05"
 
 
 @lru_cache(maxsize=1)
@@ -41,7 +43,7 @@ def build_discovery_document() -> dict[str, Any]:
     CN: 为 GET 探针构建紧凑的人类可读 discovery 文档。
     """
     return {
-        "protocolVersion": LATEST_PROTOCOL_VERSION,
+        "protocolVersion": MCP_PROTOCOL_VERSION,
         "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
         "capabilities": {
             "tools": {"list": True, "call": True},

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_lambda.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_lambda.py
@@ -27,6 +27,39 @@ def _load_lambda_wrappers():
 render_lambda_wrapper = _load_lambda_wrappers().render_lambda_wrapper
 
 
+def _write_fake_staged_packages(target: Path, *, function_name: str) -> None:
+    """EN: Create the staged service and vendored awslabs packages used by packaging tests.
+    CN: 为打包测试创建 staged service 与 vendored awslabs 包。"""
+    package_root = target / "serverless_mcp"
+    package_root.mkdir(parents=True, exist_ok=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    handler_file = {
+        "ingest": "ingest_handler.py",
+        "extract_prepare": "extract_handler.py",
+        "extract_sync": "extract_handler.py",
+        "extract_submit": "extract_handler.py",
+        "extract_poll": "extract_handler.py",
+        "extract_persist": "extract_handler.py",
+        "extract_mark_failed": "extract_handler.py",
+        "embed": "embed_handler.py",
+        "remote_mcp": "remote_mcp_handler.py",
+        "backfill": "backfill_handler.py",
+        "job_status": "job_status_handler.py",
+    }[function_name]
+    (package_root / handler_file).write_text("lambda_handler = object()\n", encoding="utf-8")
+
+    awslabs_root = target / "awslabs" / "mcp_lambda_handler"
+    awslabs_root.mkdir(parents=True, exist_ok=True)
+    (awslabs_root / "__init__.py").write_text(
+        "from .mcp_lambda_handler import MCPLambdaHandler\n",
+        encoding="utf-8",
+    )
+    (awslabs_root / "mcp_lambda_handler.py").write_text(
+        "class MCPLambdaHandler:\n    pass\n",
+        encoding="utf-8",
+    )
+
+
 def _load_package_script():
     script_path = Path(__file__).resolve().parents[4] / "tools" / "packaging" / "serverless_mcp" / "package_lambda.py"
     module_name = "package_lambda_test_module"
@@ -69,23 +102,7 @@ def test_package_lambda_generates_wrapper_and_project_sources(tmp_path, monkeypa
             return
 
         target = Path(args[args.index("--target") + 1])
-        package_root = target / "serverless_mcp"
-        package_root.mkdir(parents=True, exist_ok=True)
-        (package_root / "__init__.py").write_text("", encoding="utf-8")
-        handler_file = {
-            "ingest": "ingest_handler.py",
-            "extract_prepare": "extract_handler.py",
-            "extract_sync": "extract_handler.py",
-            "extract_submit": "extract_handler.py",
-            "extract_poll": "extract_handler.py",
-            "extract_persist": "extract_handler.py",
-            "extract_mark_failed": "extract_handler.py",
-            "embed": "embed_handler.py",
-            "remote_mcp": "remote_mcp_handler.py",
-            "backfill": "backfill_handler.py",
-            "job_status": "job_status_handler.py",
-        }[function_name]
-        (package_root / handler_file).write_text("lambda_handler = object()\n", encoding="utf-8")
+        _write_fake_staged_packages(target, function_name=function_name)
 
     monkeypatch.setattr(module, "_run", fake_run)
     monkeypatch.setattr(
@@ -115,7 +132,52 @@ def test_package_lambda_generates_wrapper_and_project_sources(tmp_path, monkeypa
 
     assert "lambda_function.py" in names
     assert "serverless_mcp/__init__.py" in names
+    assert "awslabs/mcp_lambda_handler/__init__.py" in names
+    assert "awslabs/mcp_lambda_handler/mcp_lambda_handler.py" in names
     assert wrapper_source == render_lambda_wrapper(function_name)
+
+
+def test_package_lambda_zip_imports_vendored_awslabs_handler(tmp_path, monkeypatch) -> None:
+    """
+    EN: The staged Lambda ZIP should import the vendored MCP handler successfully.
+    CN: staged Lambda ZIP 应能成功导入 vendored MCP handler。
+    """
+    module = _load_package_script()
+    output_dir = tmp_path / "dist"
+
+    def fake_run(*args: str) -> None:
+        if "--target" not in args:
+            return
+
+        target = Path(args[args.index("--target") + 1])
+        _write_fake_staged_packages(target, function_name="remote_mcp")
+
+    monkeypatch.setattr(module, "_run", fake_run)
+
+    zip_path = module.build_lambda_package(
+        function_key="remote_mcp",
+        repo_name="serverless-kb-mcp",
+        output_dir=output_dir,
+    )
+
+    with ZipFile(zip_path) as archive:
+        extracted = tmp_path / "unzipped"
+        archive.extractall(extracted)
+
+    saved_modules = {
+        name: sys.modules.pop(name)
+        for name in list(sys.modules)
+        if name == "awslabs" or name.startswith("awslabs.")
+    }
+    sys.path.insert(0, str(extracted))
+    try:
+        import awslabs.mcp_lambda_handler as handler_module
+        from awslabs.mcp_lambda_handler import MCPLambdaHandler
+
+        assert handler_module.MCPLambdaHandler is MCPLambdaHandler
+    finally:
+        sys.path.remove(str(extracted))
+        sys.modules.update(saved_modules)
 
 
 def test_package_lambda_reuses_shared_staging_for_same_dependency_group(tmp_path, monkeypatch) -> None:
@@ -133,10 +195,7 @@ def test_package_lambda_reuses_shared_staging_for_same_dependency_group(tmp_path
             return
 
         target = Path(args[args.index("--target") + 1])
-        package_root = target / "serverless_mcp"
-        package_root.mkdir(parents=True, exist_ok=True)
-        (package_root / "__init__.py").write_text("", encoding="utf-8")
-        (package_root / "remote_mcp_handler.py").write_text("lambda_handler = object()\n", encoding="utf-8")
+        _write_fake_staged_packages(target, function_name="remote_mcp")
 
     monkeypatch.setattr(module, "_run", fake_run)
 
@@ -171,14 +230,9 @@ def test_build_lambda_packages_reuses_each_dependency_group_once(tmp_path, monke
             return
 
         target = Path(args[args.index("--target") + 1])
+        _write_fake_staged_packages(target, function_name="remote_mcp")
         package_root = target / "serverless_mcp"
-        package_root.mkdir(parents=True, exist_ok=True)
-        (package_root / "__init__.py").write_text("", encoding="utf-8")
-        for handler_file in (
-            "remote_mcp_handler.py",
-            "extract_handler.py",
-        ):
-            (package_root / handler_file).write_text("lambda_handler = object()\n", encoding="utf-8")
+        (package_root / "extract_handler.py").write_text("lambda_handler = object()\n", encoding="utf-8")
 
     monkeypatch.setattr(module, "_run", fake_run)
 

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
-from mcp.types import LATEST_PROTOCOL_VERSION
-
 from serverless_mcp.domain.models import (
     ChunkManifest,
     ExtractedChunk,
@@ -19,6 +17,7 @@ from serverless_mcp.domain.models import (
     S3ObjectRef,
 )
 from serverless_mcp.entrypoints import remote_mcp as remote_mcp_handler
+from serverless_mcp.mcp_gateway.server import MCP_PROTOCOL_VERSION
 import serverless_mcp.mcp_gateway.tools.get_document_excerpt as excerpt_tool_module
 import serverless_mcp.mcp_gateway.tools.get_ingestion_status as status_tool_module
 import serverless_mcp.mcp_gateway.tools.list_document_versions as versions_tool_module
@@ -199,7 +198,7 @@ def _build_api_gateway_event(body: dict[str, object], *, session_id: str | None 
     headers = {
         "accept": "application/json, text/event-stream",
         "content-type": "application/json; charset=utf-8",
-        "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+        "mcp-protocol-version": MCP_PROTOCOL_VERSION,
     }
     if session_id:
         headers["mcp-session-id"] = session_id
@@ -248,7 +247,7 @@ def test_discovery_get_returns_query_gateway_document() -> None:
 
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
-    assert payload["protocolVersion"] == LATEST_PROTOCOL_VERSION
+    assert payload["protocolVersion"] == MCP_PROTOCOL_VERSION
     assert payload["endpoint"] == "/mcp"
     assert payload["serverInfo"]["name"] == "mcp-doc-pipeline"
     assert "resources" not in payload["capabilities"]
@@ -274,7 +273,7 @@ def test_lambda_handler_initialize_tools_list_and_call(monkeypatch) -> None:
                 "id": 1,
                 "method": "initialize",
                 "params": {
-                    "protocolVersion": LATEST_PROTOCOL_VERSION,
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
                     "capabilities": {},
                     "clientInfo": {"name": "pytest", "version": "1.0.0"},
                 },
@@ -287,9 +286,24 @@ def test_lambda_handler_initialize_tools_list_and_call(monkeypatch) -> None:
     assert initialize_response["headers"]["MCP-Version"] == "0.6"
     session_id = initialize_response["headers"]["MCP-Session-Id"]
     initialize_payload = json.loads(initialize_response["body"])
-    assert initialize_payload["result"]["protocolVersion"] == "2024-11-05"
+    assert initialize_payload["result"]["protocolVersion"] == MCP_PROTOCOL_VERSION
     assert initialize_payload["result"]["serverInfo"]["name"] == "mcp-doc-pipeline"
     assert initialize_payload["result"]["capabilities"]["tools"] == {"list": True, "call": True}
+
+    initialized_notification = remote_mcp_handler.lambda_handler(
+        _build_api_gateway_event(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+            session_id=session_id,
+        ),
+        None,
+    )
+
+    assert initialized_notification["statusCode"] == 202
+    assert initialized_notification["body"] == ""
 
     tools_list_response = remote_mcp_handler.lambda_handler(
         _build_api_gateway_event(
@@ -313,6 +327,20 @@ def test_lambda_handler_initialize_tools_list_and_call(monkeypatch) -> None:
         "list_document_versions",
         "get_ingestion_status",
     }
+
+    stateless_tools_list_response = remote_mcp_handler.lambda_handler(
+        _build_api_gateway_event(
+            {
+                "jsonrpc": "2.0",
+                "id": 22,
+                "method": "tools/list",
+                "params": {},
+            }
+        ),
+        None,
+    )
+
+    assert stateless_tools_list_response["statusCode"] == 200
 
     tools_call_response = remote_mcp_handler.lambda_handler(
         _build_api_gateway_event(
@@ -342,6 +370,50 @@ def test_lambda_handler_initialize_tools_list_and_call(monkeypatch) -> None:
     assert content["results"][0]["delivery"]["url"].startswith("https://cdn.example.com/")
     assert context.query_service.calls[0]["tenant_id"] == "tenant-a"
     assert context.query_service.calls[0]["security_scope"] == ()
+
+
+def test_lambda_handler_rejects_invalid_json_and_invalid_tool_params(monkeypatch) -> None:
+    """
+    EN: The vendored handler should reject malformed JSON and invalid tool calls.
+    CN: vendored handler 应拒绝损坏 JSON 和非法 tool 调用。
+    """
+    _install_gateway_context(monkeypatch)
+
+    parse_error_response = remote_mcp_handler.lambda_handler(
+        {
+            "httpMethod": "POST",
+            "path": "/mcp",
+            "headers": {"content-type": "application/json"},
+            "body": "{\"jsonrpc\": \"2.0\",",
+        },
+        None,
+    )
+
+    assert parse_error_response["statusCode"] == 400
+    assert "Parse error" in json.loads(parse_error_response["body"])["error"]["message"]
+
+    invalid_params_response = remote_mcp_handler.lambda_handler(
+        _build_api_gateway_event(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_documents",
+                    "arguments": {
+                        "tenant_id": "tenant-a",
+                    },
+                },
+            },
+            session_id="session-a",
+        ),
+        None,
+    )
+
+    assert invalid_params_response["statusCode"] == 500
+    invalid_params_payload = json.loads(invalid_params_response["body"])
+    assert invalid_params_payload["error"]["code"] == -32603
+    assert "Error executing tool" in invalid_params_payload["error"]["message"]
 
 
 def test_gateway_tools_return_business_payloads(monkeypatch) -> None:

--- a/ocr-service/tools/packaging/serverless_mcp/package_lambda.py
+++ b/ocr-service/tools/packaging/serverless_mcp/package_lambda.py
@@ -6,6 +6,7 @@ CN: 通过暂存服务依赖并注入 handler wrapper 来构建单个 Lambda ZIP
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import subprocess
 import sys
@@ -157,8 +158,31 @@ def _ensure_project_staging(*, label: str) -> Path:
     )
 
     _prune_transient_files(staging)
+    _validate_staged_imports(staging)
     _SHARED_STAGING_CACHE[cache_key] = _SharedStaging(tempdir=tempdir, staging=staging)
     return staging
+
+
+def _validate_staged_imports(staging: Path) -> None:
+    """EN: Fail fast if the staged Lambda payload cannot import the vendored MCP handler.
+    CN: 如果暂存的 Lambda 产物无法导入 vendored MCP handler，则尽早失败。"""
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(staging) if not pythonpath else f"{staging}{os.pathsep}{pythonpath}"
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from awslabs.mcp_lambda_handler import MCPLambdaHandler\n"
+                "import awslabs.mcp_lambda_handler as module\n"
+                "assert module.MCPLambdaHandler is MCPLambdaHandler\n"
+                "print(module.__file__)\n"
+            ),
+        ],
+        check=True,
+        env=env,
+    )
 
 
 def _run(*args: str) -> None:


### PR DESCRIPTION
## 变更摘要

本次 PR 只做 MCP gateway 的定点修复，不改 ingestion 主流程，也不重构入口基础设施。
问题是 discovery 文档里的 `protocolVersion` 与 vendored `awslabs.mcp_lambda_handler` 实际 `initialize` 返回值存在分叉，同时打包链路缺少对 vendored handler 的构建后 import 校验。
这次改动把 discovery 版本常量收敛到与真实 `initialize` 相同的值，并在 Lambda 打包阶段增加 fail-fast import smoke，确保 staged artifact、zip 产物和运行时导入路径一致。
没有改 ingestion pipeline、Step Functions、OCR worker 或底层 JSON-RPC 路由。
对外结果是：MCP 生命周期测试可跑通，且构建产物里可以稳定 import `awslabs.mcp_lambda_handler`。

Closes #99

## 关联 Issue

- 关联 issue：#99
- 关闭关系：Closes #99
- 如果没有关联 issue，请说明原因：不适用

## 变更类型

- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [x] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [ ] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围

- 受影响的目录：`ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/`、`ocr-service/ocr-pipeline/tests/unit/serverless_mcp/`、`ocr-service/tools/packaging/serverless_mcp/`
- 受影响的模块 / 服务：query-side MCP gateway、Lambda 打包脚本、MCP 协议回归测试
- 受影响的 workflow：无
- 受影响的脚本 / 任务：`package_lambda.py`
- 受影响的数据结构 / 配置：无新增环境变量；仅复用了现有 `MCP_SESSION_TABLE` / `REMOTE_MCP_SESSION_TABLE`
- 是否影响默认 PR 门禁：是，新增/修改的测试会在默认 pytest 门禁中执行
- 是否影响部署 / 回滚：影响 Lambda ZIP 产物校验，部署流程不变

## 详细说明

### 1. 主要改动

- 改动点 1：将 discovery 文档的 `protocolVersion` 收敛到与 vendored handler 真实 `initialize` 响应一致的常量。
- 改动点 2：在 `package_lambda.py` 中增加 staged artifact import 校验，确保 `awslabs.mcp_lambda_handler` 会进入最终产物。
- 改动点 3：补齐 MCP 生命周期和打包闭环测试，包括 `initialize`、`notifications/initialized`、`tools/list`、`tools/call`、非法 JSON、非法参数和 zip import smoke。

### 2. 设计选择

- 为什么采用当前方案：这是最小修复路径，保留现有 query-side gateway 和 vendored handler 架构，只消除协议分叉和打包闭环缺口。
- 备选方案是什么：改成外部 pip 依赖或重构为新的协议层。
- 为什么没有选择备选方案：会扩大变更面，也不符合当前“定点修复”的要求。

### 3. 兼容性

- 是否向后兼容：是，对外入口、路径和 tool 名称不变。
- 是否需要迁移：不需要。
- 是否需要重建索引 / 重新部署 / 重新生成产物：需要重新构建 Lambda ZIP，发布新产物即可。
- 是否引入新环境变量 / 新配置项：否。

### 4. 代码 / 文件清单

- 新增文件：无
- 修改文件：
  - `ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/server.py`
  - `ocr-service/tools/packaging/serverless_mcp/package_lambda.py`
  - `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py`
  - `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_lambda.py`
  - `ocr-service/ocr-pipeline/README.md`
- 删除文件：无
- 重命名文件：无

## 验证

### 本地验证

- 执行的命令：
  - `uv run --project . pytest -q tests/unit/serverless_mcp/test_remote_mcp_smoke.py tests/unit/serverless_mcp/test_package_lambda.py`
  - `uv run --project . pytest -q`
  - `uv run --project . ruff check ocr-pipeline/src/serverless_mcp/mcp_gateway/server.py ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py ocr-pipeline/tests/unit/serverless_mcp/test_package_lambda.py tools/packaging/serverless_mcp/package_lambda.py`
  - `uv run --project . python ../tools/packaging/serverless_mcp/package_lambda.py --function remote_mcp --repo-name serverless-kb-mcp --output-dir /tmp/serverless-mcp-dist`
- 命令输出结论：
  - 定点测试通过：`18 passed`
  - 全量测试通过：`263 passed, 2 skipped`
  - Ruff 通过：`All checks passed!`
  - 真实打包脚本通过，并打印出 staged 产物中的 `awslabs/mcp_lambda_handler/__init__.py` 路径
- 相关截图 / 日志 / 链接：无

### 自动化验证

- [x] 单元测试
- [x] 集成测试
- [x] 静态检查
- [x] 构建检查
- [ ] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：协议版本一致性、`initialize -> notifications/initialized -> tools/list -> tools/call`、非法 JSON / 非法参数、zip import smoke、真实打包脚本校验
- 失败项：无
- 未执行项及原因：workflow / CI 检查未单独触发，本地验证已覆盖对应代码路径

## 风险与回滚

- 主要风险：vendored handler 更新后，如果真实 `initialize` 版本再次变化，discovery 常量需要同步更新。
- 风险缓解方式：协议回归测试会直接覆盖 discovery / initialize 一致性；打包脚本会在构建期尽早失败。
- 回滚方式：回退本 PR 即可恢复到修复前状态。
- 回滚后遗留影响：无
- 是否需要灰度：不需要

## 对业务 / 运维的影响

- 是否影响线上行为：只影响 MCP 查询侧协议文档和 Lambda 产物验证，不改变业务查询逻辑。
- 是否影响部署流程：部署流程不变，只是在构建阶段多了一道 import 校验。
- 是否影响监控 / 告警：否
- 是否影响成本 / 性能：否
- 是否影响运维手册：README 已补充 vendored handler 来源说明

## 截图 / 录屏 / 示例

- 截图：无
- 录屏：无
- 示例输入：`initialize`、`notifications/initialized`、`tools/list`、`tools/call`
- 示例输出：discovery 与 initialize 的 `protocolVersion` 同为 `2024-11-05`

## 待确认事项

- [ ] 无

## Reviewer 关注点

- 请重点检查：`protocolVersion` 不再引用 `mcp.types.LATEST_PROTOCOL_VERSION`，而是与实际 initialize 行为对齐
- 请重点验证：`package_lambda.py` 的 staged import 校验能否在真实构建中尽早失败
- 请重点确认：没有改 ingestion pipeline、Step Functions、OCR worker 或协议路由层

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
