### PR TITLE
Refactor markdown chunking pipeline with markdown-it-py + semchunk

### DIFF
--- a/docs/open-source-boundaries.md
+++ b/docs/open-source-boundaries.md
@@ -15,6 +15,9 @@
 - 已使用 `tiktoken`。
 - 作用：更接近真实 embedding 模型的 token 边界，减少字符比例估算带来的偏差。
 - 保留字符启发式回退，确保部署环境没有 `tiktoken` 时仍可运行。
+- 已使用 `semchunk`。
+- 作用：在 Markdown 结构化分块之后，对超长 section 做轻量、语义感知的二次切分，避免把整段文本硬切成纯字符片段。
+- `semchunk` 只负责候选切分，最终 token 上限仍由 `tiktoken` 进行精确校验。
 
 ### 2. Markdown 解析
 

--- a/ocr-service/ocr-pipeline/README.md
+++ b/ocr-service/ocr-pipeline/README.md
@@ -12,7 +12,7 @@
 - `serverless_mcp/mcp_gateway/`：查询侧 MCP gateway，负责协议装配、tool 注册和 query-side service 调度。
 - `serverless_mcp/entrypoints/`：Lambda 与 API 入口层，只保留 handler 与最薄适配。
 - `serverless_mcp/extract/`、`serverless_mcp/embed/`、`serverless_mcp/query/`、`serverless_mcp/status/`、`serverless_mcp/ocr/`：业务实现与应用服务。
-- `serverless_mcp/ocr/` 里的 PaddleOCR 异步结果处理现在遵循“`jsonUrl` 保留回放、`markdownUrl` 作为 chunk 切分输入”的分工，不再从 JSON 自行合成 Markdown。
+- `serverless_mcp/ocr/` 里的 PaddleOCR 异步结果处理现在遵循“`jsonUrl` 保留回放、`markdownUrl` 作为 chunk 切分输入”的分工，不再从 JSON 自行合成 Markdown；Markdown chunking 进一步使用 `markdown-it-py + semchunk + tiktoken` 保证结构感知和 token 安全。
 - `serverless_mcp/storage/`：持久化实现，包括状态、manifest、projection 和路径工具。
 - `tests/`：服务包级测试。
 

--- a/ocr-service/ocr-pipeline/pyproject.toml
+++ b/ocr-service/ocr-pipeline/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pypdf>=5.4.0",
   "python-docx>=1.1.2",
   "python-pptx>=1.0.2",
+  "semchunk>=2.2.2",
   "tiktoken>=0.7.0",
   "requests>=2.32.0",
 ]

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/markdown_chunker.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/markdown_chunker.py
@@ -1,0 +1,651 @@
+"""
+EN: Markdown-aware chunking helpers for Lambda-friendly embedding pipelines.
+CN: 面向 Lambda 的 Markdown 感知 chunking 辅助工具。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+import re
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from markdown_it import MarkdownIt
+
+
+@dataclass(slots=True)
+class MarkdownBlock:
+    """
+    EN: Syntax-aware Markdown block extracted from a parsed token stream.
+    CN: 从解析后的 token 流中提取的具备语法感知的 Markdown block。
+    """
+
+    block_type: str
+    text: str
+    header_path: tuple[str, ...]
+    start_line: int
+    end_line: int
+    is_atomic: bool
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MarkdownChunk:
+    """
+    EN: Final Markdown chunk ready for manifest materialization and embedding.
+    CN: 可直接用于 manifest 落盘和 embedding 的最终 Markdown chunk。
+    """
+
+    text: str
+    header_path: tuple[str, ...]
+    token_estimate: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MarkdownSection:
+    """
+    EN: Coarse section assembled from Markdown blocks under one breadcrumb path.
+    CN: 由同一面包屑路径下的 Markdown block 聚合得到的粗粒度 section。
+    """
+
+    header_path: tuple[str, ...]
+    blocks: list[MarkdownBlock]
+    start_line: int
+    end_line: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def text(self) -> str:
+        """
+        EN: Render the section as Markdown text separated by blank lines.
+        CN: 用空行分隔后将 section 渲染为 Markdown 文本。
+        """
+        return "\n\n".join(block.text for block in self.blocks if block.text).strip()
+
+
+DEFAULT_SOFT_TOKEN_RATIO = 0.82
+ATX_HEADING_PATTERN = re.compile(r"^#{1,6}\s+\S")
+FENCE_PATTERN = re.compile(r"^(```+|~~~+)")
+ATOMIC_OPEN_TYPES = {"blockquote_open", "bullet_list_open", "ordered_list_open", "table_open"}
+ATOMIC_BLOCK_TYPES = {"fence", "code_block", "html_block"}
+
+
+@lru_cache(maxsize=1)
+def _markdown_parser() -> MarkdownIt:
+    """
+    EN: Build a Markdown parser with CommonMark plus table support.
+    CN: 构建支持 table 的 CommonMark Markdown 解析器。
+    """
+    parser = MarkdownIt("commonmark")
+    try:
+        parser.enable("table")
+    except (AttributeError, KeyError, ValueError):
+        pass
+    return parser
+
+
+def normalize_markdown_text(text: str) -> str:
+    """
+    EN: Normalize Markdown text by collapsing CRLF and trimming extra blank lines.
+    CN: 规范化 Markdown 文本，折叠 CRLF 并收敛多余空行。
+    """
+    normalized = text.replace("\r\n", "\n")
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+    return normalized.strip()
+
+
+def parse_markdown_blocks(markdown_text: str, *, token_counter: Callable[[str], int] | None = None) -> list[MarkdownBlock]:
+    """
+    EN: Parse Markdown into syntax-aware blocks with breadcrumb metadata.
+    CN: 将 Markdown 解析为带面包屑元数据的语法感知 block。
+    """
+    text = normalize_markdown_text(markdown_text)
+    if not text:
+        return []
+
+    lines = text.splitlines()
+    tokens = _markdown_parser().parse(text)
+    blocks: list[MarkdownBlock] = []
+    consumed_spans: list[tuple[int, int]] = []
+    header_stack: list[str] = []
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.type == "heading_open" and token.map:
+            level = _heading_level(token)
+            title = _extract_inline_text(tokens, index + 1)
+            header_stack[:] = header_stack[: max(0, level - 1)]
+            if title:
+                header_stack.append(title)
+            start_line, end_line = token.map
+            block_text = _slice_lines(lines, start_line, end_line)
+            if block_text:
+                blocks.append(
+                    MarkdownBlock(
+                        block_type=f"heading_h{level}",
+                        text=block_text,
+                        header_path=tuple(header_stack),
+                        start_line=start_line + 1,
+                        end_line=end_line,
+                        is_atomic=True,
+                        metadata={
+                            "level": level,
+                            "line_span": (start_line + 1, end_line),
+                            "token_estimate": token_counter(block_text) if token_counter else None,
+                        },
+                    )
+                )
+                consumed_spans.append((start_line, end_line))
+            index += 1
+            continue
+
+        if token.type in ATOMIC_BLOCK_TYPES and token.map:
+            start_line, end_line = token.map
+            if _is_covered_by_span(start_line, end_line, consumed_spans):
+                index += 1
+                continue
+            block_text = _slice_lines(lines, start_line, end_line)
+            if block_text:
+                blocks.append(
+                    MarkdownBlock(
+                        block_type=_classify_atomic_token(token.type),
+                        text=block_text,
+                        header_path=tuple(header_stack),
+                        start_line=start_line + 1,
+                        end_line=end_line,
+                        is_atomic=True,
+                        metadata={
+                            "token_type": token.type,
+                            "line_span": (start_line + 1, end_line),
+                            "token_estimate": token_counter(block_text) if token_counter else None,
+                        },
+                    )
+                )
+                consumed_spans.append((start_line, end_line))
+            index += 1
+            continue
+
+        if token.type in ATOMIC_OPEN_TYPES and token.map:
+            start_line, end_line = token.map
+            if _is_covered_by_span(start_line, end_line, consumed_spans):
+                index += 1
+                continue
+            block_text = _slice_lines(lines, start_line, end_line)
+            if block_text:
+                blocks.append(
+                    MarkdownBlock(
+                        block_type=_classify_atomic_token(token.type),
+                        text=block_text,
+                        header_path=tuple(header_stack),
+                        start_line=start_line + 1,
+                        end_line=end_line,
+                        is_atomic=True,
+                        metadata={
+                            "token_type": token.type,
+                            "line_span": (start_line + 1, end_line),
+                            "token_estimate": token_counter(block_text) if token_counter else None,
+                        },
+                    )
+                )
+                consumed_spans.append((start_line, end_line))
+            index += 1
+            continue
+
+        if token.type == "paragraph_open" and token.map:
+            start_line, end_line = token.map
+            if _is_covered_by_span(start_line, end_line, consumed_spans):
+                index += 1
+                continue
+            block_text = _slice_lines(lines, start_line, end_line)
+            if block_text:
+                blocks.append(
+                    MarkdownBlock(
+                        block_type="paragraph",
+                        text=block_text,
+                        header_path=tuple(header_stack),
+                        start_line=start_line + 1,
+                        end_line=end_line,
+                        is_atomic=True,
+                        metadata={
+                            "token_type": token.type,
+                            "line_span": (start_line + 1, end_line),
+                            "token_estimate": token_counter(block_text) if token_counter else None,
+                        },
+                    )
+                )
+                consumed_spans.append((start_line, end_line))
+            index += 1
+            continue
+
+        index += 1
+
+    return [block for block in blocks if block.text]
+
+
+def group_blocks_into_sections(blocks: Sequence[MarkdownBlock]) -> list[MarkdownSection]:
+    """
+    EN: Group parsed blocks into breadcrumb-aligned coarse sections.
+    CN: 按面包屑路径将解析后的 block 聚合为粗粒度 section。
+    """
+    sections: list[MarkdownSection] = []
+    current_blocks: list[MarkdownBlock] = []
+    current_path: tuple[str, ...] = ()
+    current_start = 0
+    current_end = 0
+
+    for block in blocks:
+        if block.block_type.startswith("heading_h"):
+            if current_blocks:
+                sections.append(
+                    MarkdownSection(
+                        header_path=current_path,
+                        blocks=current_blocks,
+                        start_line=current_start,
+                        end_line=current_end,
+                        metadata={
+                            "section_kind": "heading_section",
+                            "block_count": len(current_blocks),
+                            "line_span": (current_start, current_end),
+                        },
+                    )
+                )
+                current_blocks = []
+
+            current_path = block.header_path
+            current_blocks = [block]
+            current_start = block.start_line
+            current_end = block.end_line
+            continue
+
+        if not current_blocks:
+            current_path = block.header_path
+            current_start = block.start_line
+
+        current_blocks.append(block)
+        current_end = block.end_line
+
+    if current_blocks:
+        sections.append(
+            MarkdownSection(
+                header_path=current_path,
+                blocks=current_blocks,
+                start_line=current_start,
+                end_line=current_end,
+                metadata={
+                    "section_kind": "preamble" if not current_path else "heading_section",
+                    "block_count": len(current_blocks),
+                    "line_span": (current_start, current_end),
+                },
+            )
+        )
+
+    return sections
+
+
+def split_markdown_for_embedding(
+    markdown_text: str,
+    *,
+    soft_token_target: int,
+    hard_token_limit: int,
+    token_counter: Callable[[str], int],
+    tokenizer: Any | None = None,
+) -> list[MarkdownChunk]:
+    """
+    EN: Split Markdown into token-safe chunks while preserving syntax-aware sections.
+    CN: 在保留语法感知 section 的前提下，将 Markdown 拆成 token 安全的 chunks。
+    """
+    text = normalize_markdown_text(markdown_text)
+    if not text:
+        return []
+
+    soft_token_target = max(1, soft_token_target)
+    hard_token_limit = max(soft_token_target, hard_token_limit)
+
+    blocks = parse_markdown_blocks(text, token_counter=token_counter)
+    if not blocks:
+        blocks = [
+            MarkdownBlock(
+                block_type="paragraph",
+                text=text,
+                header_path=(),
+                start_line=1,
+                end_line=len(text.splitlines()) or 1,
+                is_atomic=True,
+                metadata={"token_estimate": token_counter(text)},
+            )
+        ]
+
+    sections = group_blocks_into_sections(blocks)
+    chunks: list[MarkdownChunk] = []
+    chunk_index = 0
+    chunker = _build_semchunk_chunker(token_counter=token_counter, soft_token_target=soft_token_target)
+
+    for section_index, section in enumerate(sections, start=1):
+        section_text = section.text
+        if not section_text:
+            continue
+
+        section_tokens = token_counter(section_text)
+        if section_tokens <= soft_token_target:
+            chunk_index += 1
+            chunks.append(
+                _build_chunk(
+                    text=section_text,
+                    header_path=section.header_path,
+                    token_counter=token_counter,
+                    chunk_index=chunk_index,
+                    section_index=section_index,
+                    part_index=None,
+                    total_parts=1,
+                    section_metadata=section.metadata,
+                )
+            )
+            continue
+
+        section_parts = chunker(section_text)
+        if not section_parts:
+            section_parts = [section_text]
+
+        for part_index, part in enumerate(section_parts, start=1):
+            normalized_part = normalize_markdown_text(part)
+            if not normalized_part:
+                continue
+
+            part_tokens = token_counter(normalized_part)
+            if part_tokens > hard_token_limit:
+                forced_parts = _force_split_markdown_text(
+                    normalized_part,
+                    hard_token_limit=hard_token_limit,
+                    token_counter=token_counter,
+                    tokenizer=tokenizer,
+                )
+            else:
+                forced_parts = [normalized_part]
+
+            for forced_index, forced_part in enumerate(forced_parts, start=1):
+                forced_part = normalize_markdown_text(forced_part)
+                if not forced_part:
+                    continue
+                chunk_index += 1
+                chunks.append(
+                    _build_chunk(
+                        text=forced_part,
+                        header_path=section.header_path,
+                        token_counter=token_counter,
+                        chunk_index=chunk_index,
+                        section_index=section_index,
+                        part_index=part_index,
+                        total_parts=len(section_parts),
+                        section_metadata=section.metadata,
+                        split_index=forced_index if len(forced_parts) > 1 else None,
+                    )
+                )
+
+    return _ensure_hard_limit(chunks, hard_token_limit=hard_token_limit, token_counter=token_counter, tokenizer=tokenizer)
+
+
+def _build_semchunk_chunker(
+    *,
+    token_counter: Callable[[str], int],
+    soft_token_target: int,
+) -> Callable[[str], list[str]]:
+    """
+    EN: Build a semchunk chunker from a token counter and token target.
+    CN: 基于 token 计数器和 token 目标构建 semchunk chunker。
+    """
+    try:
+        import semchunk
+    except ImportError:
+        return lambda text: _naive_sentence_split(text, token_counter=token_counter, soft_token_target=soft_token_target)
+
+    try:
+        return semchunk.chunkerify(token_counter, soft_token_target)
+    except Exception:
+        return lambda text: _naive_sentence_split(text, token_counter=token_counter, soft_token_target=soft_token_target)
+
+
+def _naive_sentence_split(text: str, *, token_counter: Callable[[str], int], soft_token_target: int) -> list[str]:
+    """
+    EN: Conservative fallback splitter used when semchunk is unavailable.
+    CN: semchunk 不可用时使用的保守回退切分器。
+    """
+    normalized = normalize_markdown_text(text)
+    if not normalized:
+        return []
+
+    if token_counter(normalized) <= soft_token_target:
+        return [normalized]
+
+    paragraphs = [segment.strip() for segment in normalized.split("\n\n") if segment.strip()]
+    if len(paragraphs) <= 1:
+        return [normalized]
+
+    parts: list[str] = []
+    current: list[str] = []
+    for paragraph in paragraphs:
+        candidate = "\n\n".join(current + [paragraph]) if current else paragraph
+        if current and token_counter(candidate) > soft_token_target:
+            parts.append("\n\n".join(current))
+            current = [paragraph]
+            continue
+        current.append(paragraph)
+    if current:
+        parts.append("\n\n".join(current))
+    return parts
+
+
+def _build_chunk(
+    *,
+    text: str,
+    header_path: tuple[str, ...],
+    token_counter: Callable[[str], int],
+    chunk_index: int,
+    section_index: int,
+    part_index: int | None,
+    total_parts: int,
+    section_metadata: dict[str, Any],
+    split_index: int | None = None,
+) -> MarkdownChunk:
+    """
+    EN: Build a chunk wrapper with provenance metadata and token estimate.
+    CN: 构建带来源元数据与 token 估算值的 chunk 包装对象。
+    """
+    metadata: dict[str, Any] = {
+        "section_index": section_index,
+        "chunk_index": chunk_index,
+        "chunking_strategy": "v2_markdown_semchunk",
+        "source_format": "markdown",
+        "section_path": list(header_path),
+        "header_path": list(header_path),
+        "section_kind": section_metadata.get("section_kind"),
+        "block_count": section_metadata.get("block_count"),
+    }
+    if part_index is not None:
+        metadata["section_part_index"] = part_index
+        metadata["section_part_count"] = total_parts
+    if split_index is not None:
+        metadata["split_index"] = split_index
+    token_estimate = token_counter(text)
+    metadata["token_estimate"] = token_estimate
+    return MarkdownChunk(text=text, header_path=header_path, token_estimate=token_estimate, metadata=metadata)
+
+
+def _ensure_hard_limit(
+    chunks: Sequence[MarkdownChunk],
+    *,
+    hard_token_limit: int,
+    token_counter: Callable[[str], int],
+    tokenizer: Any | None,
+) -> list[MarkdownChunk]:
+    """
+    EN: Enforce a hard token ceiling on every chunk with a final exact fallback.
+    CN: 对每个 chunk 强制执行硬 token 上限，并提供最终精确回退。
+    """
+    safe_chunks: list[MarkdownChunk] = []
+    for chunk in chunks:
+        if token_counter(chunk.text) <= hard_token_limit:
+            safe_chunks.append(chunk)
+            continue
+        for forced_index, forced_text in enumerate(
+            _force_split_markdown_text(
+                chunk.text,
+                hard_token_limit=hard_token_limit,
+                token_counter=token_counter,
+                tokenizer=tokenizer,
+            ),
+            start=1,
+        ):
+            forced_text = normalize_markdown_text(forced_text)
+            if not forced_text:
+                continue
+            safe_chunks.append(
+                MarkdownChunk(
+                    text=forced_text,
+                    header_path=chunk.header_path,
+                    token_estimate=token_counter(forced_text),
+                    metadata={
+                        **chunk.metadata,
+                        "split_index": forced_index,
+                        "token_estimate": token_counter(forced_text),
+                    },
+                )
+            )
+    return safe_chunks
+
+
+def _force_split_markdown_text(
+    text: str,
+    *,
+    hard_token_limit: int,
+    token_counter: Callable[[str], int],
+    tokenizer: Any | None,
+) -> list[str]:
+    """
+    EN: Force-split Markdown text when semantic splitting still exceeds the hard limit.
+    CN: 当语义切分后仍超出硬限制时，对 Markdown 文本执行强制切分。
+    """
+    normalized = normalize_markdown_text(text)
+    if not normalized:
+        return []
+
+    if tokenizer is not None and hasattr(tokenizer, "encode") and hasattr(tokenizer, "decode"):
+        try:
+            tokens = tokenizer.encode(normalized)
+        except Exception:
+            tokens = None
+        if tokens is not None:
+            if len(tokens) <= hard_token_limit:
+                return [normalized]
+            parts: list[str] = []
+            start = 0
+            while start < len(tokens):
+                end = min(start + hard_token_limit, len(tokens))
+                part = normalize_markdown_text(tokenizer.decode(tokens[start:end]))
+                if part:
+                    parts.append(part)
+                if end <= start:
+                    end = min(start + 1, len(tokens))
+                start = end
+            return parts
+
+    approx_chars = max(1, hard_token_limit * 4)
+    if len(normalized) <= approx_chars:
+        return [normalized]
+
+    parts: list[str] = []
+    remaining = normalized
+    while remaining:
+        if token_counter(remaining) <= hard_token_limit:
+            parts.append(remaining)
+            break
+        cut = _find_text_cut(remaining, approx_chars=approx_chars)
+        part = normalize_markdown_text(remaining[:cut])
+        if not part:
+            part = normalize_markdown_text(remaining[:approx_chars])
+            cut = min(approx_chars, len(remaining))
+        parts.append(part)
+        remaining = remaining[cut:].lstrip()
+    return [part for part in parts if part]
+
+
+def _find_text_cut(text: str, *, approx_chars: int) -> int:
+    """
+    EN: Find a conservative cut point near the approximate character budget.
+    CN: 在近似字符预算附近寻找保守切分点。
+    """
+    if len(text) <= approx_chars:
+        return len(text)
+    window = text[:approx_chars]
+    candidates = ["\n\n# ", "\n# ", "\n## ", "\n### ", "\n#### ", "\n##### ", "\n###### ", "\n\n", "\n"]
+    half_window = max(1, len(window) // 2)
+    for marker in candidates:
+        index = window.rfind(marker)
+        if index >= half_window:
+            return index + len(marker.rstrip())
+    return approx_chars
+
+
+def _slice_lines(lines: Sequence[str], start_line: int, end_line: int) -> str:
+    """
+    EN: Slice source lines into a Markdown block while trimming outer whitespace.
+    CN: 从源行中切出 Markdown block，并裁剪外围空白。
+    """
+    if start_line >= end_line:
+        return ""
+    return normalize_markdown_text("\n".join(lines[start_line:end_line]))
+
+
+def _is_covered_by_span(start_line: int, end_line: int, spans: Sequence[tuple[int, int]]) -> bool:
+    """
+    EN: Check whether a line range is already covered by a previously captured span.
+    CN: 检查某个行区间是否已被之前捕获的 span 覆盖。
+    """
+    for span_start, span_end in spans:
+        if start_line >= span_start and end_line <= span_end:
+            return True
+    return False
+
+
+def _extract_inline_text(tokens: Sequence[Any], index: int) -> str:
+    """
+    EN: Extract inline text from a token stream.
+    CN: 从 token 流中提取 inline 文本。
+    """
+    if index < 0 or index >= len(tokens):
+        return ""
+    token = tokens[index]
+    if token.type != "inline":
+        return ""
+    return normalize_markdown_text(token.content)
+
+
+def _heading_level(token: Any) -> int:
+    """
+    EN: Resolve the heading level from a MarkdownIt token.
+    CN: 从 MarkdownIt token 中解析 heading 层级。
+    """
+    if getattr(token, "tag", "").startswith("h") and token.tag[1:].isdigit():
+        return int(token.tag[1:])
+    return 1
+
+
+def _classify_atomic_token(token_type: str) -> str:
+    """
+    EN: Map a MarkdownIt token type to a stable block type label.
+    CN: 将 MarkdownIt token 类型映射为稳定的 block 类型标签。
+    """
+    if token_type == "fence":
+        return "code_fence"
+    if token_type == "code_block":
+        return "code_block"
+    if token_type == "html_block":
+        return "html_block"
+    if token_type == "blockquote_open":
+        return "blockquote"
+    if token_type in {"bullet_list_open", "ordered_list_open"}:
+        return "list"
+    if token_type == "table_open":
+        return "table"
+    return token_type

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/policy.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/policy.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from markdown_it import MarkdownIt
 
+from serverless_mcp.extract.markdown_chunker import split_markdown_for_embedding
 from serverless_mcp.runtime.observability import emit_trace
 from serverless_mcp.domain.models import EmbeddingPolicy, ExtractedChunk
 
@@ -169,8 +170,8 @@ def split_text_for_embedding(
     preferred_breaks: Iterable[str] = STRUCTURAL_BREAK_MARKERS,
 ) -> list[str]:
     """
-    EN: Split text into Markdown-aware chunks, falling back to tight token windows when needed.
-    CN: 鍏堟寜 Markdown 缁撴瀯鍒囧潡锛屾棤娉曟弧瓒抽檺鍒舵椂鍥為€€鍒扮揣鍑戠殑 token 绐楀彛銆?
+    EN: Split text into Markdown-aware chunks, using semchunk first and exact token fallback second.
+    CN: 先用 Markdown-aware + semchunk 切分，再用精确 token 回退兜底。
 
     Args:
         text:
@@ -192,11 +193,16 @@ def split_text_for_embedding(
         return []
 
     max_tokens = max(1, max_tokens)
-    blocks = _split_markdown_sections(text)
-    parts: list[str] = []
-    for block in blocks:
-        parts.extend(_pack_markdown_block(block, max_tokens=max_tokens, preferred_breaks=tuple(preferred_breaks)))
-    return [part for part in parts if part]
+    tokenizer = _get_token_encoder()
+    soft_token_target = max(1, min(max_tokens, round(max_tokens * 0.82)))
+    chunks = split_markdown_for_embedding(
+        text,
+        soft_token_target=soft_token_target,
+        hard_token_limit=max_tokens,
+        token_counter=estimate_tokens,
+        tokenizer=tokenizer,
+    )
+    return [chunk.text for chunk in chunks if chunk.text]
 
 
 def expand_oversized_chunks(

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/workflow.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/workflow.py
@@ -289,10 +289,10 @@ class StepFunctionsExtractWorkflow:
             elapsed_ms=round((monotonic() - markdown_download_start) * 1000, 2),
         )
         build_start = monotonic()
-        manifest = self._require_manifest_builder().build_manifest(
+        manifest = self._require_manifest_builder().build_manifest_from_markdown(
             source=job.source,
-            json_lines=json_lines,
             markdown_text=markdown_text,
+            json_lines=json_lines,
             binary_loader=ocr_client.download_binary,
         )
         emit_trace(

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/ocr/paddle_manifest_builder.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/ocr/paddle_manifest_builder.py
@@ -1,6 +1,6 @@
 """
-EN: PaddleOCR manifest builder that converts JSONL results into chunk manifests.
-CN: 同上。
+EN: PaddleOCR manifest builder that converts JSONL + Markdown results into chunk manifests.
+CN: 将 PaddleOCR 的 JSONL 和 Markdown 结果转换为 chunk manifest。
 """
 from __future__ import annotations
 
@@ -16,16 +16,16 @@ from serverless_mcp.domain.models import ChunkManifest, ExtractedAsset, Extracte
 from serverless_mcp.extract.policy import (
     DEFAULT_POLICY,
     estimate_tokens,
-    expand_oversized_chunks,
     normalize_text,
-    section_hint_from_markdown,
 )
+from serverless_mcp.extract.markdown_chunker import split_markdown_for_embedding
+from serverless_mcp.extract.policy import _get_token_encoder
 
 
 class PaddleOCRManifestBuilder:
     """
-    EN: Build chunk manifest from PaddleOCR JSONL output with text and image assets.
-    CN: 浠?PaddleOCR JSONL 杈撳嚭鏋勫缓鍖呭惈鏂囨湰鍜屽浘鐗囪祫浜х殑 chunk manifest銆?
+    EN: Build markdown-first chunk manifests from PaddleOCR async output.
+    CN: 从 PaddleOCR 异步输出构建 markdown-first 的 chunk manifest。
     """
 
     def build_manifest(
@@ -37,30 +37,55 @@ class PaddleOCRManifestBuilder:
         binary_loader: Callable[[str], tuple[bytes, str | None]],
     ) -> ChunkManifest:
         """
-        EN: Parse PaddleOCR JSONL and Markdown results and build a markdown-first manifest.
-        CN: 解析 PaddleOCR JSONL 和 Markdown 结果，并构建以 Markdown 为主的 manifest。
+        EN: Backward-compatible wrapper that keeps the JSONL raw asset while delegating to Markdown-first chunking.
+        CN: 兼容旧调用入口，保留 JSONL 原始资产，并委托给 Markdown-first chunking。
+        """
+        return self.build_manifest_from_markdown(
+            source=source,
+            markdown_text=markdown_text,
+            binary_loader=binary_loader,
+            json_lines=json_lines,
+        )
+
+    def build_manifest_from_markdown(
+        self,
+        *,
+        source: S3ObjectRef,
+        markdown_text: str,
+        binary_loader: Callable[[str], tuple[bytes, str | None]],
+        json_lines: list[dict[str, Any]] | None = None,
+    ) -> ChunkManifest:
+        """
+        EN: Build a markdown-first manifest and keep JSONL as a replay/debug asset when available.
+        CN: 构建 markdown-first manifest，并在可用时保留 JSONL 作为回放 / 调试资产。
         """
         chunks: list[ExtractedChunk] = []
         assets: list[ExtractedAsset] = []
         asset_index = 0
         image_asset_count = 0
-        layout_markdown_asset_count = 0
+        markdown_asset_count = 0
         document_markdown_asset_count = 0
+        page_count = len(json_lines) if json_lines is not None else 0
         spec = get_format_spec(doc_type="pdf", source_format="paddleocr_async")
 
         # EN: Preserve raw JSONL as an asset for reproducibility and debugging.
         # CN: 同上。
-        raw_json_payload = _dump_json_lines(json_lines)
-        assets.append(
-            ExtractedAsset(
-                asset_id="ocr#raw-jsonl",
-                chunk_type="ocr_json_chunk",
-                mime_type="application/x-ndjson",
-                payload=raw_json_payload,
-                page_no=None,
-                metadata=spec.asset_metadata(relative_path="raw.jsonl", source_field="json_lines", page_count=len(json_lines)),
+        if json_lines is not None:
+            raw_json_payload = _dump_json_lines(json_lines)
+            assets.append(
+                ExtractedAsset(
+                    asset_id="ocr#raw-jsonl",
+                    chunk_type="ocr_json_chunk",
+                    mime_type="application/x-ndjson",
+                    payload=raw_json_payload,
+                    page_no=None,
+                    metadata=spec.asset_metadata(
+                        relative_path="raw.jsonl",
+                        source_field="json_lines",
+                        page_count=page_count,
+                    ),
+                )
             )
-        )
 
         image_urls = _collect_markdown_image_urls(markdown_text)
         local_asset_paths: dict[str, str] = {}
@@ -73,44 +98,52 @@ class PaddleOCRManifestBuilder:
                 binary_loader=binary_loader,
                 url=image_url,
                 image_name=PurePosixPath(urlparse(image_url).path).name or f"asset-{asset_index:06d}",
-                metadata=spec.asset_metadata(source_field="markdown.images", page_count=len(json_lines)),
+                metadata=spec.asset_metadata(source_field="markdown.images", page_count=page_count),
             )
             assets.append(image_asset)
             local_asset_paths[image_url] = image_asset.metadata["relative_path"]
 
         rewritten_markdown_text = self._rewrite_markdown_links(markdown_text, local_asset_paths) if markdown_text else ""
-        markdown_sections = section_hint_from_markdown(rewritten_markdown_text)
-        if not markdown_sections:
-            normalized = normalize_text(rewritten_markdown_text)
-            markdown_sections = [((), normalized)] if normalized else []
+        markdown_chunks = split_markdown_for_embedding(
+            rewritten_markdown_text,
+            soft_token_target=DEFAULT_POLICY.safe_text_tokens,
+            hard_token_limit=DEFAULT_POLICY.max_input_tokens,
+            token_counter=estimate_tokens,
+            tokenizer=_get_token_encoder(),
+        )
 
-        for layout_index, (section_path, section_text) in enumerate(markdown_sections, start=1):
-            rewritten_section = self._rewrite_markdown_links(section_text, local_asset_paths) if section_text else ""
+        for layout_index, markdown_chunk in enumerate(markdown_chunks, start=1):
             assets.append(
                 ExtractedAsset(
                     asset_id=f"ocr#markdown-section-{layout_index:06d}",
                     chunk_type="document_markdown_chunk",
                     mime_type="text/markdown",
-                    payload=rewritten_section.encode("utf-8"),
+                    payload=markdown_chunk.text.encode("utf-8"),
                     page_no=None,
                     metadata=spec.asset_metadata(
                         relative_path=f"sections/section-{layout_index:06d}.md",
                         source_field="markdown.text",
-                        page_count=len(markdown_sections),
+                        page_count=len(markdown_chunks),
                         layout_index=layout_index,
                     ),
                 )
             )
-            layout_markdown_asset_count += 1
+            markdown_asset_count += 1
             chunks.append(
                 ExtractedChunk(
                     chunk_id=f"chunk#{layout_index:06d}",
                     chunk_type="section_text_chunk",
-                    text=rewritten_section,
+                    text=markdown_chunk.text,
                     doc_type="pdf",
-                    token_estimate=estimate_tokens(rewritten_section),
-                    section_path=section_path,
-                    metadata=spec.chunk_metadata(layout_index=layout_index),
+                    token_estimate=markdown_chunk.token_estimate,
+                    section_path=markdown_chunk.header_path,
+                    metadata=spec.chunk_metadata(layout_index=layout_index)
+                    | markdown_chunk.metadata
+                    | {
+                        "layout_index": layout_index,
+                        "section_path": list(markdown_chunk.header_path),
+                        "header_path": list(markdown_chunk.header_path),
+                    },
                 )
             )
 
@@ -125,15 +158,11 @@ class PaddleOCRManifestBuilder:
                     metadata=spec.asset_metadata(
                         relative_path="document.md",
                         source_field="markdownUrl",
-                        page_count=len(markdown_sections) or 1,
+                        page_count=len(markdown_chunks) or 1,
                     ),
                 )
             )
         document_markdown_asset_count = int(bool(rewritten_markdown_text))
-
-        # EN: Split oversized chunks to stay within embedding token limits.
-        # CN: 鎷嗗垎瓒呭ぇ chunk 浠ヤ繚鎸佸湪 embedding token 闄愬埗鍐呫€?
-        chunks = expand_oversized_chunks(chunks, safe_text_tokens=DEFAULT_POLICY.safe_text_tokens)
 
         return ChunkManifest(
             source=source,
@@ -141,14 +170,15 @@ class PaddleOCRManifestBuilder:
             chunks=chunks,
             assets=assets,
             metadata={
-                "page_count": len(json_lines),
+                "page_count": page_count,
                 "page_image_asset_count": image_asset_count,
-                "raw_json_asset_count": 1,
-                "layout_markdown_asset_count": layout_markdown_asset_count,
+                "raw_json_asset_count": int(json_lines is not None),
+                "layout_markdown_asset_count": markdown_asset_count,
                 "document_markdown_asset_count": document_markdown_asset_count,
-                "markdown_asset_count": layout_markdown_asset_count + document_markdown_asset_count,
+                "markdown_asset_count": markdown_asset_count + document_markdown_asset_count,
                 "ocr_engine": "PaddleOCR-VL-1.5",
                 "source_format": spec.source_format,
+                "chunking_strategy": "v2_markdown_semchunk",
             },
         )
 

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py
@@ -170,7 +170,7 @@ class _FakeOCRClient:
 class _FakeManifestBuilder:
     # EN: Stand-in for PaddleOCRManifestBuilder returning a fixed manifest.
     # CN: 杩斿洖鍥哄畾 manifest 鐨?PaddleOCRManifestBuilder 鏇胯韩銆?
-    def build_manifest(self, *, source, json_lines, markdown_text, binary_loader):
+    def build_manifest_from_markdown(self, *, source, markdown_text, binary_loader, json_lines=None):
         return ChunkManifest(
             source=source,
             doc_type="pdf",

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_chunker.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_chunker.py
@@ -1,0 +1,140 @@
+"""
+EN: Tests for the Markdown chunker covering structure-aware parsing and token-safe splitting.
+CN: 针对 Markdown chunker 的测试，覆盖结构感知解析和 token-safe 拆分。
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from serverless_mcp.extract.markdown_chunker import parse_markdown_blocks, split_markdown_for_embedding
+
+
+class _CharTokenizer:
+    # EN: Simple tokenizer stub that treats every character as one token.
+    # CN: 将每个字符视为一个 token 的简单 tokenizer stub。
+    def encode(self, text: str) -> list[str]:
+        return list(text)
+
+    def decode(self, tokens: list[str]) -> str:
+        return "".join(tokens)
+
+
+def _count_chars(text: str) -> int:
+    return len(text)
+
+
+def test_parse_markdown_blocks_tracks_header_paths_and_atomic_blocks() -> None:
+    """
+    EN: Markdown block parsing preserves header breadcrumbs and atomic block types.
+    CN: Markdown block 解析需要保留标题面包屑和原子 block 类型。
+    """
+    markdown_text = (
+        "# Title\n\n"
+        "Intro paragraph.\n\n"
+        "## Details\n\n"
+        "> quoted line\n\n"
+        "- item one\n"
+        "- item two\n\n"
+        "```python\n"
+        "print('hello')\n"
+        "```\n\n"
+        "| a | b |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+    )
+
+    blocks = parse_markdown_blocks(markdown_text, token_counter=_count_chars)
+
+    assert any(block.block_type == "heading_h1" and block.header_path == ("Title",) for block in blocks)
+    assert any(block.block_type == "heading_h2" and block.header_path == ("Title", "Details") for block in blocks)
+    assert any(block.block_type == "blockquote" and block.is_atomic for block in blocks)
+    assert any(block.block_type == "list" and block.is_atomic for block in blocks)
+    assert any(block.block_type == "code_fence" and block.is_atomic for block in blocks)
+    assert any(block.block_type == "table" and block.is_atomic for block in blocks)
+    assert any(block.header_path == ("Title", "Details") for block in blocks if block.block_type in {"blockquote", "list", "code_fence", "table"})
+
+
+def test_split_markdown_for_embedding_merges_small_sections_and_keeps_atomic_blocks_intact() -> None:
+    """
+    EN: Small Markdown sections are merged while fenced code, lists, tables, and blockquotes stay intact.
+    CN: 小 section 会合并，同时 fenced code、list、table 和 blockquote 不应被切坏。
+    """
+    markdown_text = (
+        "# Intro\n\n"
+        "Short paragraph one.\n\n"
+        "Short paragraph two.\n\n"
+        "> quoted note\n\n"
+        "- item one\n"
+        "- item two\n\n"
+        "```python\n"
+        "print('hello')\n"
+        "```\n\n"
+        "| a | b |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+    )
+
+    chunks = split_markdown_for_embedding(
+        markdown_text,
+        soft_token_target=400,
+        hard_token_limit=500,
+        token_counter=_count_chars,
+        tokenizer=_CharTokenizer(),
+    )
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.header_path == ("Intro",)
+    assert chunk.metadata["source_format"] == "markdown"
+    assert chunk.metadata["chunking_strategy"] == "v2_markdown_semchunk"
+    assert "```python\nprint('hello')\n```" in chunk.text
+    assert "| a | b |\n|---|---|\n| 1 | 2 |" in chunk.text
+    assert "- item one\n- item two" in chunk.text
+    assert "> quoted note" in chunk.text
+    assert chunk.token_estimate <= 500
+
+
+def test_split_markdown_for_embedding_splits_long_paragraphs_by_semantic_chunks() -> None:
+    """
+    EN: Long Markdown sections are split into multiple token-safe chunks.
+    CN: 长 Markdown section 应被拆成多个 token-safe chunk。
+    """
+    markdown_text = "# Intro\n\n" + ("alpha beta gamma delta epsilon zeta eta theta iota kappa " * 18)
+
+    chunks = split_markdown_for_embedding(
+        markdown_text,
+        soft_token_target=80,
+        hard_token_limit=120,
+        token_counter=_count_chars,
+        tokenizer=_CharTokenizer(),
+    )
+
+    assert len(chunks) > 1
+    assert all(chunk.token_estimate <= 120 for chunk in chunks)
+    assert chunks[0].header_path == ("Intro",)
+    assert all(chunk.metadata["source_format"] == "markdown" for chunk in chunks)
+
+
+def test_split_markdown_for_embedding_uses_exact_fallback_when_semchunk_is_noop(monkeypatch) -> None:
+    """
+    EN: The exact token window fallback activates when semchunk returns an oversized chunk unchanged.
+    CN: 当 semchunk 仍返回超大 chunk 时，精确 token 窗口回退必须生效。
+    """
+    fake_semchunk = types.SimpleNamespace(chunkerify=lambda *_args, **_kwargs: (lambda text: [text]))
+    monkeypatch.setitem(sys.modules, "semchunk", fake_semchunk)
+
+    markdown_text = "# Intro\n\n" + ("x" * 260)
+    chunks = split_markdown_for_embedding(
+        markdown_text,
+        soft_token_target=60,
+        hard_token_limit=90,
+        token_counter=_count_chars,
+        tokenizer=_CharTokenizer(),
+    )
+
+    assert len(chunks) > 1
+    assert all(chunk.token_estimate <= 90 for chunk in chunks)
+    assert chunks[0].text.startswith("# Intro")
+

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py
@@ -42,7 +42,8 @@ def test_paddle_manifest_builder_splits_layout_markdown_into_multiple_assets() -
     assert manifest.chunks[0].text.startswith("# Page 1 A")
     assert "assets/asset-000001.png" in manifest.chunks[0].text
     assert "assets/asset-000002.png" in manifest.chunks[1].text
-    assert all(chunk.metadata["source_format"] == "paddleocr_async" for chunk in manifest.chunks)
+    assert all(chunk.metadata["source_format"] == "markdown" for chunk in manifest.chunks)
+    assert all(chunk.metadata["chunking_strategy"] == "v2_markdown_semchunk" for chunk in manifest.chunks)
     assert [chunk.metadata["layout_index"] for chunk in manifest.chunks] == [1, 2]
 
     assert len(manifest.assets) == 6
@@ -63,9 +64,9 @@ def test_paddle_manifest_builder_splits_layout_markdown_into_multiple_assets() -
     assert assets_by_path["assets/asset-000002.png"].chunk_type == "page_image_chunk"
     assert section_md_asset_1.chunk_type == "document_markdown_chunk"
     assert section_md_asset_1.mime_type == "text/markdown"
-    assert section_md_asset_1.payload == b"# Page 1 A\nhello world\n\n![inline](assets/asset-000001.png)"
+    assert section_md_asset_1.payload == b"# Page 1 A\n\nhello world\n\n![inline](assets/asset-000001.png)"
     assert section_md_asset_2.chunk_type == "document_markdown_chunk"
-    assert section_md_asset_2.payload == b"## Page 1 B\nsecond block\n\n![inline-2](assets/asset-000002.png)"
+    assert section_md_asset_2.payload == b"## Page 1 B\n\nsecond block\n\n![inline-2](assets/asset-000002.png)"
     assert document_md_asset.chunk_type == "document_markdown_chunk"
     assert document_md_asset.mime_type == "text/markdown"
     assert document_md_asset.payload == (
@@ -89,7 +90,7 @@ def test_paddle_manifest_builder_recursively_splits_oversized_layout_markdown(mo
             return "".join(tokens)
 
     monkeypatch.setattr(policy, "_get_token_encoder", lambda: _FakeEncoder())
-    monkeypatch.setattr(builder_module, "DEFAULT_POLICY", SimpleNamespace(safe_text_tokens=40))
+    monkeypatch.setattr(builder_module, "DEFAULT_POLICY", SimpleNamespace(safe_text_tokens=40, max_input_tokens=40))
 
     builder = PaddleOCRManifestBuilder()
     source = S3ObjectRef(tenant_id="tenant-a", bucket="bucket-a", key="docs/scan.pdf", version_id="v1")

--- a/ocr-service/uv.lock
+++ b/ocr-service/uv.lock
@@ -353,6 +353,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +737,25 @@ wheels = [
 ]
 
 [[package]]
+name = "mpire"
+version = "2.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/93/80ac75c20ce54c785648b4ed363c88f148bf22637e10c9863db4fbe73e74/mpire-2.10.2.tar.gz", hash = "sha256:f66a321e93fadff34585a4bfa05e95bd946cf714b442f51c529038eb45773d97", size = 271270, upload-time = "2024-05-07T14:00:31.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/14/1db1729ad6db4999c3a16c47937d601fcb909aaa4224f5eca5a2f145a605/mpire-2.10.2-py3-none-any.whl", hash = "sha256:d627707f7a8d02aa4c7f7d59de399dec5290945ddf7fbd36cbb1d6ebb37a51fb", size = 272756, upload-time = "2024-05-07T14:00:29.633Z" },
+]
+
+[package.optional-dependencies]
+dill = [
+    { name = "multiprocess" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -769,6 +797,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
     { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
     { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
 ]
 
 [[package]]
@@ -1518,6 +1563,19 @@ wheels = [
 ]
 
 [[package]]
+name = "semchunk"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpire", extra = ["dill"] },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/d9/3206b435cc375452a075e49a928a6d0764cdfd9d693c4a9e7fce3d637548/semchunk-4.0.0.tar.gz", hash = "sha256:d1017b7572cfcb2337e6ba2cad8a7963716e8772463ba85a968d718496feec7e", size = 23222, upload-time = "2026-03-23T05:48:39.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/d3/159cb53cfa520a2b8375aae3784a76e65baf3e96fea596eb388daa88c441/semchunk-4.0.0-py3-none-any.whl", hash = "sha256:77dba8b6bd533ede115708372463b3703dbf0075d3f4ac2af0f4f3ed7b6af795", size = 17722, upload-time = "2026-03-23T05:48:37.49Z" },
+]
+
+[[package]]
 name = "serverless-kb-mcp"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1562,6 +1620,7 @@ dependencies = [
     { name = "python-pptx" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "semchunk" },
     { name = "tiktoken" },
 ]
 
@@ -1584,6 +1643,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.0" },
+    { name = "semchunk", specifier = ">=2.2.2" },
     { name = "tiktoken", specifier = ">=0.7.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Closes #103

## 变更摘要

请用 3 到 8 句话说明这次 PR 的核心目标、变更范围和最终结果。

- 问题是什么：飞桨返回的是 Markdown，但现有 chunking 仍有一层偏重 JSON 结构的分块逻辑，超长 section 也缺少统一的 Markdown-aware、token-safe 二次切分流水线。
- 为什么要改：需要把 Markdown 作为主输入，并用 markdown-it-py + semchunk + tiktoken 做轻量、可控、适合 Lambda 的分块。
- 这次改了什么：新增 markdown_chunker，把 policy.py 的文本切分入口收敛到新 chunker，重构 PaddleOCR manifest builder 使用 markdown-first chunk 生成，补齐相关测试和依赖锁。
- 没有改什么：没有改 ingestion 主流程、Step Functions 主状态机、Embed/Query 层契约，也没有引入重依赖。
- 对外可见的结果：PaddleOCR Markdown 输出现在会被直接切成结构更稳、token 更安全的 chunks，且 final token 上限由 tiktoken 校验。

## 关联 Issue

- 关联 issue：#103
- 关闭关系：Closes #103，并且必须以普通文本裸写，不能放进反引号、代码块或引用块
- 如果是跨仓库引用，请写明完整链接：不适用
- 如果没有关联 issue，请说明原因：不适用

## 变更类型

请选择所有适用项：

- [ ] 缺陷修复
- [x] 新功能
- [x] 重构
- [x] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [x] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围

说明这次改动会影响哪些层、模块、流程或外部接口。

- 受影响的目录：`ocr-service/ocr-pipeline/src/serverless_mcp/extract/`、`ocr-service/ocr-pipeline/src/serverless_mcp/ocr/`、`ocr-service/ocr-pipeline/tests/unit/serverless_mcp/`、`docs/`
- 受影响的模块 / 服务：Markdown chunker、embedding policy、PaddleOCR manifest builder、相关单测
- 受影响的 workflow：无直接 workflow 变更
- 受影响的脚本 / 任务：`uv lock`
- 受影响的数据结构 / 配置：`semchunk` 新依赖、chunk metadata 中增加 `chunking_strategy` / `source_format=markdown`
- 是否影响默认 PR 门禁：是，会影响全量 pytest 与 ruff 检查
- 是否影响部署 / 回滚：需要重新打包 Lambda；回滚只需回退本 PR

## 详细说明

按“改动点 -> 目的 -> 结果”的顺序逐条说明。

### 1. 主要改动

- 改动点 1：新增 `serverless_mcp/extract/markdown_chunker.py`，实现 Markdown block 解析、section 合并、semchunk 二次切分和精确 token fallback。
- 改动点 2：把 `extract/policy.py` 的 `split_text_for_embedding()` 收敛到新 chunker，保留旧接口外形。
- 改动点 3：重构 `ocr/paddle_manifest_builder.py` 和 `extract/workflow.py`，让 manifest 生成直接以 Markdown chunk 为主，同时保留 JSONL 原始资产。

### 2. 设计选择

- 为什么采用当前方案：它最贴合 Lambda 场景，依赖轻、可测试，而且能保留 Markdown 结构和 token 上限安全。
- 备选方案是什么：继续用纯字符切分，或者引入更重的文档处理栈。
- 为什么没有选择备选方案：会更难维护，也不符合当前运行环境约束。

### 3. 兼容性

- 是否向后兼容：是，JSONL 原始资产路径保留，旧的 `split_text_for_embedding()` 外部调用也保留。
- 是否需要迁移：不需要数据迁移。
- 是否需要重建索引 / 重新部署 / 重新生成产物：需要重新部署 Lambda 代码。
- 是否引入新环境变量 / 新配置项：否。

### 4. 代码 / 文件清单

- 新增文件：
  - `ocr-service/ocr-pipeline/src/serverless_mcp/extract/markdown_chunker.py`
  - `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_chunker.py`
- 修改文件：
  - `ocr-service/ocr-pipeline/pyproject.toml`
  - `ocr-service/ocr-pipeline/src/serverless_mcp/extract/policy.py`
  - `ocr-service/ocr-pipeline/src/serverless_mcp/extract/workflow.py`
  - `ocr-service/ocr-pipeline/src/serverless_mcp/ocr/paddle_manifest_builder.py`
  - `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py`
  - `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py`
  - `ocr-service/ocr-pipeline/README.md`
  - `docs/open-source-boundaries.md`
  - `ocr-service/uv.lock`
- 删除文件：无
- 重命名文件：无

## 验证

请明确列出实际执行过的验证步骤，而不是只写“已测试”。

### 本地验证

- 执行的命令：
  - `uv run --project ocr-service/ocr-pipeline ruff check ...`
  - `uv run --project ocr-service/ocr-pipeline pytest -q ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_chunker.py ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_policy.py ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_handler.py`
  - `uv run --project ocr-pipeline pytest -q`（在 `ocr-service/` 目录下执行）
- 命令输出结论：
  - 定点测试通过：`30 passed`
  - 全量测试通过：`270 passed, 2 skipped`
  - Ruff 通过：`All checks passed!`
- 相关截图 / 日志 / 链接：无

### 自动化验证

- [x] 单元测试
- [x] 集成测试
- [x] 静态检查
- [ ] 构建检查
- [ ] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：Markdown block 解析、header breadcrumb 保留、code/table/list/blockquote 原子块、semchunk 二次切分、fallback 强制切分、manifest builder 输出、工作流传递、全量 pytest
- 失败项：无
- 未执行项及原因：构建检查和 workflow / CI 检查未单独触发，本地测试已覆盖主要代码路径

## 风险与回滚

说明这次 PR 最可能带来的风险，以及如果需要回退，应该怎么回退。

- 主要风险：Markdown 结构化切分策略和旧的 section 组合顺序存在细微差异，可能影响少量 chunk 边界。
- 风险缓解方式：补了结构、atomic block、token 上限和 fallback 回归测试。
- 回滚方式：回退本 PR 即可恢复旧实现。
- 回滚后遗留影响：无
- 是否需要灰度：不需要

## 对业务 / 运维的影响

- 是否影响线上行为：会影响 OCR Markdown 结果如何切 chunk，但不会改变 ingestion 主流程。
- 是否影响部署流程：部署流程不变，只需要重新发布新的 Lambda 代码。
- 是否影响监控 / 告警：否。
- 是否影响成本 / 性能：依赖轻量，chunk 质量更稳定，token 安全性更强。
- 是否影响运维手册：是，README 和开源边界说明已经同步更新。

## 截图 / 录屏 / 示例

如果改动涉及 UI、文档排版、流程演示或输出格式，请在这里补充。

- 截图：无
- 录屏：无
- 示例输入：包含多级标题、列表、表格、blockquote 和 fenced code block 的 Markdown
- 示例输出：按 section 聚合并在超长 section 上使用 semchunk + tiktoken 二次切分的 chunk 列表

## 待确认事项

如果还有未决问题，请在这里列出，并标明由谁确认。

- [ ] 无

## Reviewer 关注点

告诉 reviewer 重点看哪里，减少来回沟通。

- 请重点检查：Markdown 原子块是否被切坏，token 上限是否真的由 tiktoken 兜底
- 请重点验证：PaddleOCR manifest builder 是否仍保留 JSONL 原始资产
- 请重点确认：没有把重依赖引入 Lambda

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
