### PR TITLE
修复 Markdown-first 提取链路与 runtime/test 收敛

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -109,21 +109,20 @@ jobs:
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_handler.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_parser.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_worker.py \
-                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embedding_runtime.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_handler.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_service.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_ingest.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_ingest_handler.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_job_status_handler.py \
-                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_entrypoints.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_runtime_imports.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_wrapper_registry.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_pipeline.py \
-                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_api.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py \
-                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_handler.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_response_serialization.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_state_machine_definition.py \
-                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_step_functions_workflow.py \
-                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_worker.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_worker.py \
                 --maxfail=1
               ;;
             packaging)
@@ -132,6 +131,8 @@ jobs:
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_extractor.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_lambda.py \
                 ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_boundaries.py \
+                ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_wrapper_registry.py \
                 --maxfail=1
               ;;
             *)
@@ -187,27 +188,28 @@ jobs:
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_handler.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_parser.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_worker.py",
-                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embedding_runtime.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_runtime_imports.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_handler.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_service.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_ingest.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_ingest_handler.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_job_status_handler.py",
-                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_entrypoints.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_wrapper_registry.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_pipeline.py",
-                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_api.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py",
-                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_handler.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_response_serialization.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_state_machine_definition.py",
-                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_step_functions_workflow.py",
-                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_worker.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_worker.py",
               ],
               "packaging": [
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_artifact_scripts.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_extractor.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_lambda.py",
                   "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_package_boundaries.py",
+                  "ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_lambda_wrapper_registry.py",
               ],
           }
 

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/entrypoints/extract_persist.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/entrypoints/extract_persist.py
@@ -18,21 +18,37 @@ def _run_persist_ocr_result(event: dict, _context: object | None) -> dict:
     """
     workflow = _get_components().workflow_for("persist_ocr_result")
     json_url = event.get("json_url")
-    if not isinstance(json_url, str) or not json_url.strip():
-        raise ValueError("json_url is required for persist_ocr_result")
-    normalized_json_url = json_url.strip()
+    normalized_json_url = json_url.strip() if isinstance(json_url, str) and json_url.strip() else None
+    markdown_url = event.get("markdown_url")
+    if not isinstance(markdown_url, str) or not markdown_url.strip():
+        raise ValueError("markdown_url is required for persist_ocr_result")
+    normalized_markdown_url = markdown_url.strip()
     job = validate_job(event.get("job"), required_for="persist_ocr_result")
     processing_state = validate_processing_state(event.get("processing_state"), required_for="persist_ocr_result")
+    trace_payload = {
+        "action": "persist_ocr_result",
+        "document_uri": job.source.document_uri,
+        "trace_id": job.trace_id,
+        "processing_state_pk": processing_state.pk,
+        "json_url_present": normalized_json_url is not None,
+        "markdown_url_host": urlparse(normalized_markdown_url).hostname,
+        "markdown_url_path": urlparse(normalized_markdown_url).path,
+    }
+    if normalized_json_url is not None:
+        trace_payload.update(
+            json_url_host=urlparse(normalized_json_url).hostname,
+            json_url_path=urlparse(normalized_json_url).path,
+        )
     emit_trace(
         "handler.dispatch",
-        action="persist_ocr_result",
-        document_uri=job.source.document_uri,
-        trace_id=job.trace_id,
-        processing_state_pk=processing_state.pk,
-        json_url_host=urlparse(normalized_json_url).hostname,
-        json_url_path=urlparse(normalized_json_url).path,
+        **trace_payload,
     )
-    return workflow.persist_ocr_result(job=job, processing_state=processing_state, json_url=normalized_json_url)
+    return workflow.persist_ocr_result(
+        job=job,
+        processing_state=processing_state,
+        json_url=normalized_json_url,
+        markdown_url=normalized_markdown_url,
+    )
 
 
 lambda_handler = build_action_handler("persist_ocr_result", _run_persist_ocr_result)

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/extractors.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/extractors.py
@@ -20,12 +20,13 @@ from pptx.enum.shapes import MSO_SHAPE_TYPE
 
 from serverless_mcp.domain.format_specs import get_format_spec
 from serverless_mcp.domain.models import ChunkManifest, ExtractedAsset, ExtractedChunk, S3ObjectRef
+from serverless_mcp.extract.markdown_chunker import split_markdown_for_embedding
 from serverless_mcp.extract.policy import (
     DEFAULT_POLICY,
     estimate_tokens,
     expand_oversized_chunks,
     normalize_text,
-    section_hint_from_markdown,
+    _get_token_encoder,
 )
 
 
@@ -150,27 +151,13 @@ class DocumentExtractor:
         """
         spec = get_format_spec(doc_type="md", source_format="markdown")
         text = body.decode("utf-8")
-        sections = section_hint_from_markdown(text)
-        chunks: list[ExtractedChunk] = []
-
-        if not sections:
-            # EN: Fallback to a single normalized chunk when no headings are detected.
-            # CN: 同上。
-            normalized = normalize_text(text)
-            sections = [((), normalized)] if normalized else []
-
-        for index, (path, section_text) in enumerate(sections, start=1):
-            chunks.append(
-                ExtractedChunk(
-                    chunk_id=f"chunk#{index:06d}",
-                    chunk_type="section_text_chunk",
-                    text=section_text,
-                    doc_type="md",
-                    token_estimate=estimate_tokens(section_text),
-                    section_path=path,
-                    metadata=spec.chunk_metadata(),
-                )
-            )
+        chunks = _build_markdown_chunks(
+            spec=spec,
+            doc_type="md",
+            markdown_text=text,
+            safe_text_tokens=ctx.safe_text_tokens,
+            source_metadata={},
+        )
 
         return ChunkManifest(
             source=ctx.source,
@@ -198,27 +185,13 @@ class DocumentExtractor:
         """
         spec = get_format_spec(doc_type="docx", source_format="python-docx")
         markdown_text = _convert_docx_to_markdown(body)
-        sections = section_hint_from_markdown(markdown_text)
-        chunks: list[ExtractedChunk] = []
-
-        if not sections:
-            # EN: Fallback to a single normalized chunk when no headings are detected.
-            # CN: 同上。
-            normalized = normalize_text(markdown_text)
-            sections = [((), normalized)] if normalized else []
-
-        for index, (path, section_text) in enumerate(sections, start=1):
-            chunks.append(
-                ExtractedChunk(
-                    chunk_id=f"chunk#{index:06d}",
-                    chunk_type="section_text_chunk",
-                    text=section_text,
-                    doc_type="docx",
-                    token_estimate=estimate_tokens(section_text),
-                    section_path=path,
-                    metadata=spec.chunk_metadata(),
-                )
-            )
+        chunks = _build_markdown_chunks(
+            spec=spec,
+            doc_type="docx",
+            markdown_text=markdown_text,
+            safe_text_tokens=ctx.safe_text_tokens,
+            source_metadata={"converter": "python-docx"},
+        )
 
         return ChunkManifest(
             source=ctx.source,
@@ -289,18 +262,46 @@ class DocumentExtractor:
                 if notes_text:
                     slide_text = normalize_text("\n".join(part for part in [slide_text, notes_text] if part))
 
-            chunks.append(
-                ExtractedChunk(
-                    chunk_id=f"chunk#{slide_no:06d}",
-                    chunk_type="slide_text_chunk",
-                    text=slide_text,
-                    doc_type="pptx",
-                    token_estimate=estimate_tokens(slide_text),
-                    slide_no=slide_no,
-                    section_path=(f"slide-{slide_no}",),
-                    metadata=spec.chunk_metadata(image_count=image_count, has_notes=bool(slide.has_notes_slide and slide.notes_slide)),
-                )
+            slide_chunks = split_markdown_for_embedding(
+                slide_text,
+                soft_token_target=ctx.safe_text_tokens,
+                hard_token_limit=ctx.safe_text_tokens,
+                token_counter=estimate_tokens,
+                tokenizer=_get_token_encoder(),
             )
+            if slide_chunks:
+                for slide_chunk_index, slide_chunk in enumerate(slide_chunks, start=1):
+                    chunks.append(
+                        ExtractedChunk(
+                            chunk_id=f"chunk#{slide_no:06d}-{slide_chunk_index:02d}"
+                            if len(slide_chunks) > 1
+                            else f"chunk#{slide_no:06d}",
+                            chunk_type="slide_text_chunk",
+                            text=slide_chunk.text,
+                            doc_type="pptx",
+                            token_estimate=slide_chunk.token_estimate,
+                            slide_no=slide_no,
+                            section_path=(f"slide-{slide_no}",),
+                            metadata=spec.chunk_metadata(
+                                image_count=image_count,
+                                has_notes=bool(slide.has_notes_slide and slide.notes_slide),
+                            )
+                            | {k: v for k, v in slide_chunk.metadata.items() if k != "source_format"},
+                        )
+                    )
+            elif normalize_text(slide_text):
+                chunks.append(
+                    ExtractedChunk(
+                        chunk_id=f"chunk#{slide_no:06d}",
+                        chunk_type="slide_text_chunk",
+                        text=normalize_text(slide_text),
+                        doc_type="pptx",
+                        token_estimate=estimate_tokens(slide_text),
+                        slide_no=slide_no,
+                        section_path=(f"slide-{slide_no}",),
+                        metadata=spec.chunk_metadata(image_count=image_count, has_notes=bool(slide.has_notes_slide and slide.notes_slide)),
+                    )
+                )
 
         return ChunkManifest(
             source=ctx.source,
@@ -473,6 +474,49 @@ def _convert_docx_to_markdown(body: bytes) -> str:
         if isinstance(block, Table):
             lines.extend(_table_to_markdown(block))
     return normalize_text("\n".join(lines))
+
+
+def _build_markdown_chunks(
+    *,
+    spec,
+    doc_type: str,
+    markdown_text: str,
+    safe_text_tokens: int,
+    source_metadata: dict[str, object],
+) -> list[ExtractedChunk]:
+    """
+    EN: Convert Markdown text into extraction chunks using Markdown-aware splitting.
+    CN: 使用 Markdown-aware splitting 将 Markdown 文本转换为 extraction chunks。
+    """
+    normalized_markdown = normalize_text(markdown_text)
+    if not normalized_markdown:
+        return []
+
+    markdown_chunks = split_markdown_for_embedding(
+        normalized_markdown,
+        soft_token_target=max(1, min(safe_text_tokens, round(safe_text_tokens * 0.82))),
+        hard_token_limit=max(1, safe_text_tokens),
+        token_counter=estimate_tokens,
+        tokenizer=_get_token_encoder(),
+    )
+    if not markdown_chunks:
+        return []
+
+    chunks: list[ExtractedChunk] = []
+    for index, markdown_chunk in enumerate(markdown_chunks, start=1):
+        chunks.append(
+            ExtractedChunk(
+                chunk_id=f"chunk#{index:06d}",
+                chunk_type="section_text_chunk",
+                text=markdown_chunk.text,
+                doc_type=doc_type,
+                token_estimate=markdown_chunk.token_estimate,
+                section_path=markdown_chunk.header_path,
+                metadata=spec.chunk_metadata(**source_metadata)
+                | {k: v for k, v in markdown_chunk.metadata.items() if k != "source_format"},
+            )
+        )
+    return chunks
 
 
 def _iter_docx_blocks(document) -> list[Paragraph | Table]:

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/handlers/persist.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/handlers/persist.py
@@ -18,25 +18,30 @@ def _run_persist_ocr_result(event: dict, _context: object | None) -> dict:
     """
     workflow = _get_components().workflow_for("persist_ocr_result")
     json_url = event.get("json_url")
-    if not isinstance(json_url, str) or not json_url.strip():
-        raise ValueError("json_url is required for persist_ocr_result")
-    normalized_json_url = json_url.strip()
+    normalized_json_url = json_url.strip() if isinstance(json_url, str) and json_url.strip() else None
     markdown_url = event.get("markdown_url")
     if not isinstance(markdown_url, str) or not markdown_url.strip():
         raise ValueError("markdown_url is required for persist_ocr_result")
     normalized_markdown_url = markdown_url.strip()
     job = validate_job(event.get("job"), required_for="persist_ocr_result")
     processing_state = validate_processing_state(event.get("processing_state"), required_for="persist_ocr_result")
+    trace_payload = {
+        "action": "persist_ocr_result",
+        "document_uri": job.source.document_uri,
+        "trace_id": job.trace_id,
+        "processing_state_pk": processing_state.pk,
+        "json_url_present": normalized_json_url is not None,
+        "markdown_url_host": urlparse(normalized_markdown_url).hostname,
+        "markdown_url_path": urlparse(normalized_markdown_url).path,
+    }
+    if normalized_json_url is not None:
+        trace_payload.update(
+            json_url_host=urlparse(normalized_json_url).hostname,
+            json_url_path=urlparse(normalized_json_url).path,
+        )
     emit_trace(
         "handler.dispatch",
-        action="persist_ocr_result",
-        document_uri=job.source.document_uri,
-        trace_id=job.trace_id,
-        processing_state_pk=processing_state.pk,
-        json_url_host=urlparse(normalized_json_url).hostname,
-        json_url_path=urlparse(normalized_json_url).path,
-        markdown_url_host=urlparse(normalized_markdown_url).hostname,
-        markdown_url_path=urlparse(normalized_markdown_url).path,
+        **trace_payload,
     )
     return workflow.persist_ocr_result(
         job=job,

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/handlers/router.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/handlers/router.py
@@ -98,12 +98,10 @@ def lambda_handler(event: dict, _context) -> dict:
                 "action": "persist_ocr_result",
                 "job": job_payload,
                 "processing_state": processing_state_payload,
-                "json_url": json_url,
-                "markdown_url": markdown_url,
             }:
-                if not isinstance(json_url, str) or not json_url.strip():
-                    raise ValueError("json_url is required for persist_ocr_result")
-                normalized_json_url = json_url.strip()
+                json_url = event.get("json_url")
+                normalized_json_url = json_url.strip() if isinstance(json_url, str) and json_url.strip() else None
+                markdown_url = event.get("markdown_url")
                 if not isinstance(markdown_url, str) or not markdown_url.strip():
                     raise ValueError("markdown_url is required for persist_ocr_result")
                 normalized_markdown_url = markdown_url.strip()
@@ -112,16 +110,23 @@ def lambda_handler(event: dict, _context) -> dict:
                     processing_state_payload,
                     required_for="persist_ocr_result",
                 )
+                trace_payload = {
+                    "action": action,
+                    "document_uri": job.source.document_uri,
+                    "trace_id": job.trace_id,
+                    "processing_state_pk": processing_state.pk,
+                    "json_url_present": normalized_json_url is not None,
+                    "markdown_url_host": urlparse(normalized_markdown_url).hostname,
+                    "markdown_url_path": urlparse(normalized_markdown_url).path,
+                }
+                if normalized_json_url is not None:
+                    trace_payload.update(
+                        json_url_host=urlparse(normalized_json_url).hostname,
+                        json_url_path=urlparse(normalized_json_url).path,
+                    )
                 emit_trace(
                     "handler.dispatch",
-                    action=action,
-                    document_uri=job.source.document_uri,
-                    trace_id=job.trace_id,
-                    processing_state_pk=processing_state.pk,
-                    json_url_host=urlparse(normalized_json_url).hostname,
-                    json_url_path=urlparse(normalized_json_url).path,
-                    markdown_url_host=urlparse(normalized_markdown_url).hostname,
-                    markdown_url_path=urlparse(normalized_markdown_url).path,
+                    **trace_payload,
                 )
                 result = workflow.persist_ocr_result(
                     job=job,

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/handlers/support.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/handlers/support.py
@@ -5,6 +5,7 @@ CN: extract handler 共享的负载校验与懒加载工作流装配。
 from __future__ import annotations
 
 from functools import cached_property, lru_cache
+from types import SimpleNamespace
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -130,9 +131,12 @@ def _build_object_state_repo(table_name: str, dynamodb_client):
     EN: Lazily construct the object state repository for the workflow state boundary.
     CN: 为工作流状态边界懒加载构建 object state repository。
     """
-    from serverless_mcp.storage.state.object_state_repository import ObjectStateRepository
+    from serverless_mcp.runtime.bootstrap import build_object_state_repo
+    from serverless_mcp.runtime.config import Settings
 
-    return ObjectStateRepository(table_name=table_name, dynamodb_client=dynamodb_client)
+    settings = Settings(object_state_table=table_name)
+    clients = SimpleNamespace(dynamodb=dynamodb_client)
+    return build_object_state_repo(settings=settings, clients=clients)
 
 
 def _build_execution_state_repo(table_name: str, dynamodb_client):
@@ -140,9 +144,12 @@ def _build_execution_state_repo(table_name: str, dynamodb_client):
     EN: Lazily construct the execution state repository for Step Functions bookkeeping.
     CN: 为 Step Functions 记账懒加载构建 execution state repository。
     """
-    from serverless_mcp.storage.state.execution_state_repository import ExecutionStateRepository
+    from serverless_mcp.runtime.bootstrap import build_execution_state_repo
+    from serverless_mcp.runtime.config import Settings
 
-    return ExecutionStateRepository(table_name=table_name, dynamodb_client=dynamodb_client)
+    settings = Settings(object_state_table="unused", execution_state_table=table_name)
+    clients = SimpleNamespace(dynamodb=dynamodb_client)
+    return build_execution_state_repo(settings=settings, clients=clients)
 
 
 def _build_manifest_repo(*, manifest_bucket: str, manifest_prefix: str, s3_client, dynamodb_client, manifest_index_table: str):
@@ -150,15 +157,17 @@ def _build_manifest_repo(*, manifest_bucket: str, manifest_prefix: str, s3_clien
     EN: Lazily construct the manifest repository for OCR persistence.
     CN: 为 OCR 持久化懒加载构建 manifest repository。
     """
-    from serverless_mcp.storage.manifest.repository import ManifestRepository
+    from serverless_mcp.runtime.bootstrap import build_manifest_repo
+    from serverless_mcp.runtime.config import Settings
 
-    return ManifestRepository(
+    settings = Settings(
+        object_state_table="unused",
         manifest_bucket=manifest_bucket,
         manifest_prefix=manifest_prefix,
-        s3_client=s3_client,
-        dynamodb_client=dynamodb_client,
         manifest_index_table=manifest_index_table,
     )
+    clients = SimpleNamespace(s3=s3_client, dynamodb=dynamodb_client)
+    return build_manifest_repo(settings=settings, clients=clients)
 
 
 def _build_embed_dispatcher(queue_url: str, sqs_client):

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/markdown_chunker.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/markdown_chunker.py
@@ -207,7 +207,7 @@ def parse_markdown_blocks(markdown_text: str, *, token_counter: Callable[[str], 
                         header_path=tuple(header_stack),
                         start_line=start_line + 1,
                         end_line=end_line,
-                        is_atomic=True,
+                        is_atomic=False,
                         metadata={
                             "token_type": token.type,
                             "line_span": (start_line + 1, end_line),
@@ -344,7 +344,14 @@ def split_markdown_for_embedding(
             )
             continue
 
-        section_parts = chunker(section_text)
+        section_parts = _split_section_blocks(
+            section,
+            token_counter=token_counter,
+            soft_token_target=soft_token_target,
+            hard_token_limit=hard_token_limit,
+            chunker=chunker,
+            tokenizer=tokenizer,
+        )
         if not section_parts:
             section_parts = [section_text]
 
@@ -384,6 +391,84 @@ def split_markdown_for_embedding(
                 )
 
     return _ensure_hard_limit(chunks, hard_token_limit=hard_token_limit, token_counter=token_counter, tokenizer=tokenizer)
+
+
+def _split_section_blocks(
+    section: MarkdownSection,
+    *,
+    token_counter: Callable[[str], int],
+    soft_token_target: int,
+    hard_token_limit: int,
+    chunker: Callable[[str], list[str]],
+    tokenizer: Any | None,
+) -> list[str]:
+    """
+    EN: Split an oversized section by packing Markdown blocks instead of slicing the whole section text.
+    CN: 将超大的 section 按 Markdown block 打包切分，而不是直接切整段 section 文本。
+    """
+    packed_chunks: list[str] = []
+    current_parts: list[str] = []
+
+    def flush_current() -> None:
+        """
+        EN: Emit the current packed chunk if there is one.
+        CN: 如果存在当前打包 chunk，则输出它。
+        """
+        if current_parts:
+            packed_chunks.append(normalize_markdown_text("\n\n".join(current_parts)))
+            current_parts.clear()
+
+    def append_unit(unit_text: str) -> None:
+        """
+        EN: Append one pre-split unit while keeping the packed chunk under the hard limit.
+        CN: 追加一个预切分单元，并保持当前打包 chunk 不超过硬限制。
+        """
+        normalized_unit = normalize_markdown_text(unit_text)
+        if not normalized_unit:
+            return
+        candidate_parts = [*current_parts, normalized_unit]
+        candidate_text = normalize_markdown_text("\n\n".join(candidate_parts))
+        if current_parts and token_counter(candidate_text) > hard_token_limit:
+            flush_current()
+            current_parts.append(normalized_unit)
+            return
+        current_parts.append(normalized_unit)
+
+    for block in section.blocks:
+        block_text = normalize_markdown_text(block.text)
+        if not block_text:
+            continue
+
+        block_tokens = token_counter(block_text)
+        if block.block_type == "paragraph" and block_tokens > soft_token_target:
+            paragraph_parts = chunker(block_text)
+            if not paragraph_parts or (
+                len(paragraph_parts) == 1 and normalize_markdown_text(paragraph_parts[0]) == block_text
+            ):
+                paragraph_parts = _force_split_markdown_text(
+                    block_text,
+                    hard_token_limit=hard_token_limit,
+                    token_counter=token_counter,
+                    tokenizer=tokenizer,
+                )
+            for paragraph_part in paragraph_parts:
+                append_unit(paragraph_part)
+            continue
+
+        if block.is_atomic and block_tokens > hard_token_limit:
+            for forced_part in _force_split_markdown_text(
+                block_text,
+                hard_token_limit=hard_token_limit,
+                token_counter=token_counter,
+                tokenizer=tokenizer,
+            ):
+                append_unit(forced_part)
+            continue
+
+        append_unit(block_text)
+
+    flush_current()
+    return packed_chunks
 
 
 def _build_semchunk_chunker(

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/extract/workflow.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/extract/workflow.py
@@ -247,40 +247,51 @@ class StepFunctionsExtractWorkflow:
         *,
         job: ExtractJobMessage,
         processing_state: ObjectStateRecord,
-        json_url: str,
+        json_url: str | None = None,
         markdown_url: str,
     ) -> dict:
         """
         EN: Download OCR output, build the manifest, and persist extraction results.
         CN: 下载 OCR 输出、构建 manifest，并持久化提取结果。
         """
-        if not json_url:
-            raise ValueError("json_url is required when persisting OCR output")
-        if not markdown_url:
+        if not isinstance(markdown_url, str) or not markdown_url.strip():
             raise ValueError("markdown_url is required when persisting OCR output")
+        if json_url is not None and not json_url.strip():
+            raise ValueError("json_url must be blank-free when provided")
+        normalized_json_url = json_url.strip() if json_url is not None else None
+        normalized_markdown_url = markdown_url.strip()
         start = monotonic()
+        trace_payload = {
+            "document_uri": job.source.document_uri,
+            "trace_id": job.trace_id,
+            "markdown_url_host": urlparse(normalized_markdown_url).hostname,
+            "markdown_url_path": urlparse(normalized_markdown_url).path,
+            "previous_version_id": processing_state.previous_version_id,
+            "json_url_present": normalized_json_url is not None,
+        }
+        if normalized_json_url is not None:
+            trace_payload.update(
+                json_url_host=urlparse(normalized_json_url).hostname,
+                json_url_path=urlparse(normalized_json_url).path,
+            )
         emit_trace(
             "persist_ocr_result.start",
-            document_uri=job.source.document_uri,
-            trace_id=job.trace_id,
-            json_url_host=urlparse(json_url).hostname,
-            json_url_path=urlparse(json_url).path,
-            markdown_url_host=urlparse(markdown_url).hostname,
-            markdown_url_path=urlparse(markdown_url).path,
-            previous_version_id=processing_state.previous_version_id,
+            **trace_payload,
         )
         ocr_client = self._require_ocr_client()
-        download_start = monotonic()
-        json_lines = ocr_client.download_json_lines(json_url)
-        emit_trace(
-            "persist_ocr_result.download_done",
-            document_uri=job.source.document_uri,
-            trace_id=job.trace_id,
-            json_line_count=len(json_lines),
-            elapsed_ms=round((monotonic() - download_start) * 1000, 2),
-        )
+        json_lines = None
+        if normalized_json_url is not None:
+            download_start = monotonic()
+            json_lines = ocr_client.download_json_lines(normalized_json_url)
+            emit_trace(
+                "persist_ocr_result.download_done",
+                document_uri=job.source.document_uri,
+                trace_id=job.trace_id,
+                json_line_count=len(json_lines),
+                elapsed_ms=round((monotonic() - download_start) * 1000, 2),
+            )
         markdown_download_start = monotonic()
-        markdown_text = ocr_client.download_markdown(markdown_url)
+        markdown_text = ocr_client.download_markdown(normalized_markdown_url)
         emit_trace(
             "persist_ocr_result.markdown_download_done",
             document_uri=job.source.document_uri,

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/query/application.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/query/application.py
@@ -181,6 +181,15 @@ class QueryService:
         if unique_object_pks:
             batch_states = self._load_execution_states_batch(object_pks=unique_object_pks)
             state_cache.update(batch_states)
+        if self._projection_state_repo is not None and sorted_candidates:
+            projection_cache.update(
+                self._load_projection_states_batch(
+                    keys=[
+                        (candidate.source.object_pk, candidate.source.version_id, candidate.match.profile_id)
+                        for candidate in sorted_candidates
+                    ]
+                )
+            )
 
         for candidate in sorted_candidates:
             metadata = sanitize_result_metadata(candidate.match.metadata)
@@ -365,6 +374,32 @@ class QueryService:
             version_id=source.version_id,
             profile_id=profile_id,
         )
+
+    def _load_projection_states_batch(
+        self,
+        *,
+        keys: list[tuple[str, str, str]],
+    ) -> dict[tuple[str, str, str], EmbeddingProjectionStateRecord | None]:
+        """
+        EN: Batch load projection states when the repository supports it, otherwise fall back per key.
+        CN: 当仓库支持时批量读取 projection state，否则按 key 回退。
+        """
+        if self._projection_state_repo is None or not keys:
+            return {}
+        batch_loader = getattr(self._projection_state_repo, "get_states_batch", None)
+        if callable(batch_loader):
+            try:
+                return batch_loader(keys=keys)
+            except TypeError:
+                pass
+        return {
+            key: self._projection_state_repo.get_state(
+                object_pk=key[0],
+                version_id=key[1],
+                profile_id=key[2],
+            )
+            for key in keys
+        }
 
     def _load_execution_state(self, *, object_pk: str) -> ObjectStateRecord | None:
         """

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/bootstrap.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/bootstrap.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass
 
 from serverless_mcp.runtime.aws_clients import AwsClientBundle, get_aws_clients
 from serverless_mcp.runtime.config import Settings, load_settings
+from serverless_mcp.storage.manifest.repository import ManifestRepository
+from serverless_mcp.storage.projection.repository import EmbeddingProjectionStateRepository
+from serverless_mcp.storage.state.execution_state_repository import ExecutionStateRepository
+from serverless_mcp.storage.state.object_state_repository import ObjectStateRepository
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,6 +25,19 @@ class RuntimeContext:
     clients: AwsClientBundle
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeRepositories:
+    """
+    EN: Shared repository bundle built from runtime settings and cached AWS clients.
+    CN: 基于运行时配置和缓存 AWS clients 构建的共享 repository 组合。
+    """
+
+    object_state_repo: ObjectStateRepository
+    execution_state_repo: ExecutionStateRepository | None = None
+    manifest_repo: ManifestRepository | None = None
+    projection_state_repo: EmbeddingProjectionStateRepository | None = None
+
+
 def build_runtime_context(*, settings: Settings | None = None, clients: AwsClientBundle | None = None) -> RuntimeContext:
     """
     EN: Resolve settings and AWS clients into a single composition-root context.
@@ -31,4 +48,63 @@ def build_runtime_context(*, settings: Settings | None = None, clients: AwsClien
     return RuntimeContext(settings=active_settings, clients=active_clients)
 
 
-__all__ = ["RuntimeContext", "build_runtime_context"]
+def build_object_state_repo(*, settings: Settings, clients: AwsClientBundle) -> ObjectStateRepository:
+    """
+    EN: Build the canonical object_state repository once from shared runtime inputs.
+    CN: 基于共享运行时输入构建唯一的 object_state repository。
+    """
+    return ObjectStateRepository(table_name=settings.object_state_table, dynamodb_client=clients.dynamodb)
+
+
+def build_execution_state_repo(*, settings: Settings, clients: AwsClientBundle) -> ExecutionStateRepository | None:
+    """
+    EN: Build the execution_state repository when the table is configured.
+    CN: 在配置了表名时构建 execution_state repository。
+    """
+    if not settings.execution_state_table:
+        return None
+    return ExecutionStateRepository(table_name=settings.execution_state_table, dynamodb_client=clients.dynamodb)
+
+
+def build_manifest_repo(*, settings: Settings, clients: AwsClientBundle) -> ManifestRepository | None:
+    """
+    EN: Build the manifest repository when manifest storage is configured.
+    CN: 在配置了 manifest 存储时构建 manifest repository。
+    """
+    if not settings.manifest_bucket or not settings.manifest_index_table:
+        return None
+    return ManifestRepository(
+        manifest_bucket=settings.manifest_bucket,
+        manifest_prefix=settings.manifest_prefix,
+        s3_client=clients.s3,
+        dynamodb_client=clients.dynamodb,
+        manifest_index_table=settings.manifest_index_table,
+    )
+
+
+def build_projection_state_repo(
+    *,
+    settings: Settings,
+    clients: AwsClientBundle,
+) -> EmbeddingProjectionStateRepository | None:
+    """
+    EN: Build the optional projection_state repository when the table is configured.
+    CN: 在配置了表名时构建可选的 projection_state repository。
+    """
+    if not settings.embedding_projection_state_table:
+        return None
+    return EmbeddingProjectionStateRepository(
+        table_name=settings.embedding_projection_state_table,
+        dynamodb_client=clients.dynamodb,
+    )
+
+
+__all__ = [
+    "RuntimeContext",
+    "RuntimeRepositories",
+    "build_runtime_context",
+    "build_object_state_repo",
+    "build_execution_state_repo",
+    "build_manifest_repo",
+    "build_projection_state_repo",
+]

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/embed_runtime.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/embed_runtime.py
@@ -9,13 +9,15 @@ from serverless_mcp.embed.asset_source import EmbedAssetSource
 from serverless_mcp.embed.backfill import EmbeddingBackfillService
 from serverless_mcp.embed.dispatcher import EmbeddingJobDispatcher
 from serverless_mcp.embed.vector_repository import S3VectorRepository
-from serverless_mcp.runtime.bootstrap import build_runtime_context
+from serverless_mcp.runtime.bootstrap import (
+    build_execution_state_repo,
+    build_manifest_repo,
+    build_object_state_repo,
+    build_projection_state_repo,
+    build_runtime_context,
+)
 from serverless_mcp.runtime.config import Settings
 from serverless_mcp.runtime.embedding_profiles import build_embedding_clients, get_write_profiles
-from serverless_mcp.storage.projection.repository import EmbeddingProjectionStateRepository
-from serverless_mcp.storage.state.execution_state_repository import ExecutionStateRepository
-from serverless_mcp.storage.manifest.repository import ManifestRepository
-from serverless_mcp.storage.state.object_state_repository import ObjectStateRepository
 
 
 def build_embed_worker(settings: Settings | None = None) -> EmbedWorker:
@@ -35,33 +37,20 @@ def build_embed_worker(settings: Settings | None = None) -> EmbedWorker:
     if not active_settings.execution_state_table:
         raise ValueError("EXECUTION_STATE_TABLE is required for embed worker")
     clients = runtime_context.clients
-    projection_state_repo = None
-    if active_settings.embedding_projection_state_table:
-        projection_state_repo = EmbeddingProjectionStateRepository(
-            table_name=active_settings.embedding_projection_state_table,
-            dynamodb_client=clients.dynamodb,
-        )
-    execution_state_repo = ExecutionStateRepository(
-        table_name=active_settings.execution_state_table,
-        dynamodb_client=clients.dynamodb,
-    )
+    projection_state_repo = build_projection_state_repo(settings=active_settings, clients=clients)
+    execution_state_repo = build_execution_state_repo(settings=active_settings, clients=clients)
+    manifest_repo = build_manifest_repo(settings=active_settings, clients=clients)
+    object_state_repo = build_object_state_repo(settings=active_settings, clients=clients)
+    if manifest_repo is None:
+        raise ValueError("MANIFEST_BUCKET and MANIFEST_INDEX_TABLE are required for embed worker")
 
     return EmbedWorker(
         embedding_clients=build_embedding_clients(active_settings, profiles=write_profiles),
         embedding_profiles={profile.profile_id: profile for profile in write_profiles},
         asset_source=EmbedAssetSource(s3_client=clients.s3),
         vector_repo=S3VectorRepository(s3vectors_client=clients.s3vectors),
-        manifest_repo=ManifestRepository(
-            manifest_bucket=active_settings.manifest_bucket,
-            manifest_prefix=active_settings.manifest_prefix,
-            s3_client=clients.s3,
-            dynamodb_client=clients.dynamodb,
-            manifest_index_table=active_settings.manifest_index_table,
-        ),
-        object_state_repo=ObjectStateRepository(
-            table_name=active_settings.object_state_table,
-            dynamodb_client=clients.dynamodb,
-        ),
+        manifest_repo=manifest_repo,
+        object_state_repo=object_state_repo,
         execution_state_repo=execution_state_repo,
         projection_state_repo=projection_state_repo,
     )
@@ -84,31 +73,18 @@ def build_backfill_service(settings: Settings | None = None) -> EmbeddingBackfil
         raise ValueError("EXECUTION_STATE_TABLE is required for embedding backfill")
     clients = runtime_context.clients
     profiles = get_write_profiles(active_settings)
-    projection_state_repo = None
-    if active_settings.embedding_projection_state_table:
-        projection_state_repo = EmbeddingProjectionStateRepository(
-            table_name=active_settings.embedding_projection_state_table,
-            dynamodb_client=clients.dynamodb,
-        )
-    execution_state_repo = ExecutionStateRepository(
-        table_name=active_settings.execution_state_table,
-        dynamodb_client=clients.dynamodb,
-    )
+    projection_state_repo = build_projection_state_repo(settings=active_settings, clients=clients)
+    execution_state_repo = build_execution_state_repo(settings=active_settings, clients=clients)
+    manifest_repo = build_manifest_repo(settings=active_settings, clients=clients)
+    object_state_repo = build_object_state_repo(settings=active_settings, clients=clients)
+    if manifest_repo is None:
+        raise ValueError("MANIFEST_BUCKET and MANIFEST_INDEX_TABLE are required for embedding backfill")
 
     return EmbeddingBackfillService(
         extraction_service=ExtractionService(),
-        object_state_repo=ObjectStateRepository(
-            table_name=active_settings.object_state_table,
-            dynamodb_client=clients.dynamodb,
-        ),
+        object_state_repo=object_state_repo,
         execution_state_repo=execution_state_repo,
-        manifest_repo=ManifestRepository(
-            manifest_bucket=active_settings.manifest_bucket,
-            manifest_prefix=active_settings.manifest_prefix,
-            s3_client=clients.s3,
-            dynamodb_client=clients.dynamodb,
-            manifest_index_table=active_settings.manifest_index_table,
-        ),
+        manifest_repo=manifest_repo,
         embed_dispatcher=EmbeddingJobDispatcher(
             queue_url=active_settings.embed_queue_url,
             sqs_client=clients.sqs,

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/ingest.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/ingest.py
@@ -15,12 +15,17 @@ from serverless_mcp.embed.vector_repository import S3VectorRepository
 from serverless_mcp.core.parsers import parse_event
 from serverless_mcp.domain.models import EmbeddingProfile, ObjectStateRecord, S3ObjectRef
 from serverless_mcp.runtime.aws_resolution import resolve_step_functions_state_machine_arn
-from serverless_mcp.runtime.bootstrap import build_runtime_context
+from serverless_mcp.runtime.bootstrap import (
+    build_manifest_repo,
+    build_object_state_repo,
+    build_projection_state_repo,
+    build_runtime_context,
+)
 from serverless_mcp.runtime.config import Settings
 from serverless_mcp.runtime.embedding_profiles import get_write_profiles
+from serverless_mcp.storage.manifest.repository import ManifestRepository
 from serverless_mcp.storage.state.execution_state_repository import ExecutionStateRepository
 from serverless_mcp.storage.projection.repository import EmbeddingProjectionStateRepository
-from serverless_mcp.storage.manifest.repository import ManifestRepository
 from serverless_mcp.storage.state.object_state_repository import DuplicateOrStaleEventError, ObjectStateRepository
 
 
@@ -300,10 +305,7 @@ def build_ingest_workflow_starter(
     state_machine_arn = resolve_step_functions_state_machine_arn(
         state_machine_ref=active_settings.step_functions_state_machine_arn,
     )
-    object_state_repo = ObjectStateRepository(
-        table_name=active_settings.object_state_table,
-        dynamodb_client=clients.dynamodb,
-    )
+    object_state_repo = build_object_state_repo(settings=active_settings, clients=clients)
     execution_state_repo = ExecutionStateRepository(
         table_name=active_settings.execution_state_table,
         dynamodb_client=clients.dynamodb,
@@ -311,22 +313,14 @@ def build_ingest_workflow_starter(
     delete_lifecycle_manager = None
     write_profiles = get_write_profiles(active_settings)
     if active_settings.manifest_bucket and active_settings.manifest_index_table and write_profiles:
-        projection_state_repo = None
-        if active_settings.embedding_projection_state_table:
-            projection_state_repo = EmbeddingProjectionStateRepository(
-                table_name=active_settings.embedding_projection_state_table,
-                dynamodb_client=clients.dynamodb,
-            )
+        projection_state_repo = build_projection_state_repo(settings=active_settings, clients=clients)
+        manifest_repo = build_manifest_repo(settings=active_settings, clients=clients)
+        if manifest_repo is None:
+            raise ValueError("MANIFEST_BUCKET and MANIFEST_INDEX_TABLE are required for ingest worker cleanup")
         delete_lifecycle_manager = DeleteMarkerGovernance(
             object_state_repo=object_state_repo,
             execution_state_repo=execution_state_repo,
-            manifest_repo=ManifestRepository(
-                manifest_bucket=active_settings.manifest_bucket,
-                manifest_prefix=active_settings.manifest_prefix,
-                s3_client=clients.s3,
-                dynamodb_client=clients.dynamodb,
-                manifest_index_table=active_settings.manifest_index_table,
-            ),
+            manifest_repo=manifest_repo,
             vector_repo=S3VectorRepository(s3vectors_client=clients.s3vectors),
             profiles=write_profiles,
             projection_state_repo=projection_state_repo,

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/query_runtime.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/runtime/query_runtime.py
@@ -6,13 +6,15 @@ from __future__ import annotations
 
 from serverless_mcp.embed.vector_repository import S3VectorRepository
 from serverless_mcp.query.application import QueryService
-from serverless_mcp.runtime.bootstrap import build_runtime_context
+from serverless_mcp.runtime.bootstrap import (
+    build_execution_state_repo,
+    build_manifest_repo,
+    build_object_state_repo,
+    build_projection_state_repo,
+    build_runtime_context,
+)
 from serverless_mcp.runtime.config import Settings
 from serverless_mcp.runtime.embedding_profiles import build_embedding_clients, get_query_profiles
-from serverless_mcp.storage.projection.repository import EmbeddingProjectionStateRepository
-from serverless_mcp.storage.state.execution_state_repository import ExecutionStateRepository
-from serverless_mcp.storage.manifest.repository import ManifestRepository
-from serverless_mcp.storage.state.object_state_repository import ObjectStateRepository
 
 
 def build_query_service(settings: Settings | None = None) -> QueryService:
@@ -30,32 +32,19 @@ def build_query_service(settings: Settings | None = None) -> QueryService:
     if not active_settings.execution_state_table:
         raise ValueError("EXECUTION_STATE_TABLE is required for the retrieval service")
     clients = runtime_context.clients
-    projection_state_repo = None
-    if active_settings.embedding_projection_state_table:
-        projection_state_repo = EmbeddingProjectionStateRepository(
-            table_name=active_settings.embedding_projection_state_table,
-            dynamodb_client=clients.dynamodb,
-        )
-    execution_state_repo = ExecutionStateRepository(
-        table_name=active_settings.execution_state_table,
-        dynamodb_client=clients.dynamodb,
-    )
+    projection_state_repo = build_projection_state_repo(settings=active_settings, clients=clients)
+    execution_state_repo = build_execution_state_repo(settings=active_settings, clients=clients)
+    manifest_repo = build_manifest_repo(settings=active_settings, clients=clients)
+    object_state_repo = build_object_state_repo(settings=active_settings, clients=clients)
+    if manifest_repo is None:
+        raise ValueError("MANIFEST_BUCKET and MANIFEST_INDEX_TABLE are required for the retrieval service")
 
     return QueryService(
         embedding_clients=build_embedding_clients(active_settings, profiles=query_profiles),
         query_profiles=query_profiles,
         vector_repo=S3VectorRepository(s3vectors_client=clients.s3vectors),
-        manifest_repo=ManifestRepository(
-            manifest_bucket=active_settings.manifest_bucket,
-            manifest_prefix=active_settings.manifest_prefix,
-            s3_client=clients.s3,
-            dynamodb_client=clients.dynamodb,
-            manifest_index_table=active_settings.manifest_index_table,
-        ),
-        object_state_repo=ObjectStateRepository(
-            table_name=active_settings.object_state_table,
-            dynamodb_client=clients.dynamodb,
-        ),
+        manifest_repo=manifest_repo,
+        object_state_repo=object_state_repo,
         execution_state_repo=execution_state_repo,
         projection_state_repo=projection_state_repo,
         profile_timeout_seconds=active_settings.query_profile_timeout_seconds,

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/storage/projection/repository.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/storage/projection/repository.py
@@ -10,6 +10,7 @@ migrations do not interfere with each other.
 """
 from __future__ import annotations
 
+import time
 from urllib.parse import quote
 
 from serverless_mcp.domain.models import EmbeddingOutcome, EmbeddingProfile, EmbeddingProjectionStateRecord, S3ObjectRef, utc_now_iso
@@ -105,6 +106,56 @@ class EmbeddingProjectionStateRepository:
         if not item:
             return None
         return _deserialize_projection_state(item)
+
+    def get_states_batch(
+        self,
+        *,
+        keys: list[tuple[str, str, str]],
+    ) -> dict[tuple[str, str, str], EmbeddingProjectionStateRecord | None]:
+        """
+        EN: Load multiple projection states in batches keyed by object/version/profile triplets.
+        CN: 按 object/version/profile 三元组批量加载多个 projection state。
+        """
+        if not keys:
+            return {}
+
+        records: dict[tuple[str, str, str], EmbeddingProjectionStateRecord | None] = {
+            key: None for key in keys
+        }
+        pending = list(keys)
+        for attempt in range(8):
+            request_items = {
+                self._table_name: {
+                    "Keys": [
+                        {
+                            "pk": {"S": _build_projection_pk(object_pk=object_pk, version_id=version_id)},
+                            "sk": {"S": profile_id},
+                        }
+                        for object_pk, version_id, profile_id in pending
+                    ],
+                    "ConsistentRead": True,
+                }
+            }
+            response = self._ddb.batch_get_item(RequestItems=request_items)
+            for item in response.get("Responses", {}).get(self._table_name, []):
+                record = _deserialize_projection_state(item)
+                records[(record.object_pk, record.version_id, record.profile_id)] = record
+
+            unprocessed_items = response.get("UnprocessedKeys", {}).get(self._table_name, {}).get("Keys") or []
+            if not unprocessed_items:
+                return records
+
+            pending = [
+                _parse_projection_key(item["pk"]["S"], item["sk"]["S"])
+                for item in unprocessed_items
+            ]
+            if attempt < 7:
+                time.sleep(min(0.05 * (2**attempt), 1.0))
+
+        raise RuntimeError(
+            "DynamoDB batch_get_item did not drain after projection state retries; "
+            f"table={self._table_name}"
+        )
 
     def list_version_records(self, *, object_pk: str, version_id: str) -> list[EmbeddingProjectionStateRecord]:
         """
@@ -394,6 +445,23 @@ def _chunked(items: list[EmbeddingProjectionStateRecord], size: int) -> list[lis
     # EN: Split a list into fixed-size batches for DynamoDB batch_write_item calls.
     # CN: 灏嗗垪琛ㄦ媶鍒嗕负鍥哄畾澶у皬鐨勬壒娆★紝鐢ㄤ簬 DynamoDB batch_write_item 璋冪敤銆?
     return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def _build_projection_pk(*, object_pk: str, version_id: str) -> str:
+    """
+    EN: Build the composite partition key used by projection state records.
+    CN: 构造 projection state record 使用的复合 partition key。
+    """
+    return f"{object_pk}#{quote(version_id, safe='')}"
+
+
+def _parse_projection_key(pk: str, sk: str) -> tuple[str, str, str]:
+    """
+    EN: Decode a projection-state composite key back into object/version/profile parts.
+    CN: 将 projection-state 复合 key 解码回 object/version/profile 三部分。
+    """
+    object_pk, version_id = pk.rsplit("#", 1)
+    return object_pk, version_id, sk
 
 
 def _deserialize_projection_state(item: dict[str, dict[str, str | bool]]) -> EmbeddingProjectionStateRecord:

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_handler.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_handler.py
@@ -136,32 +136,33 @@ def test_lambda_handler_raises_clear_error_for_invalid_job_payload(monkeypatch: 
         )
 
 
-def test_lambda_handler_rejects_empty_json_url_for_persist_ocr_result(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_lambda_handler_allows_missing_json_url_for_persist_ocr_result(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    EN: Verify that persist_ocr_result rejects a blank json_url value.
-    CN: 楠岃瘉 persist_ocr_result 鎷掔粷绌虹櫧鐨?json_url 鍊笺€?
+    EN: Verify that persist_ocr_result accepts markdown-first payloads without json_url.
+    CN: 验证 persist_ocr_result 可以接收不带 json_url 的 markdown-first 负载。
     """
     workflow = _FakeWorkflow()
     components = _FakeComponents(workflow)
     monkeypatch.setattr("serverless_mcp.extract.handlers.router._get_components", lambda: components)
 
-    with pytest.raises(ValueError, match="json_url is required for persist_ocr_result"):
-        lambda_handler(
-            {
-                "action": "persist_ocr_result",
-                "job": _job_payload(),
-                "processing_state": {
-                    "pk": "tenant-a#bucket-a#docs/guide.md",
-                    "latest_version_id": "v1",
-                    "latest_sequencer": "0001",
-                    "extract_status": "EXTRACTED",
-                    "embed_status": "PENDING",
-                },
-                "json_url": "   ",
-                "markdown_url": "https://example.com/result.md",
+    result = lambda_handler(
+        {
+            "action": "persist_ocr_result",
+            "job": _job_payload(),
+            "processing_state": {
+                "pk": "tenant-a#bucket-a#docs/guide.md",
+                "latest_version_id": "v1",
+                "latest_sequencer": "0001",
+                "extract_status": "EXTRACTED",
+                "embed_status": "PENDING",
             },
-            None,
-        )
+            "markdown_url": "https://example.com/result.md",
+        },
+        None,
+    )
+
+    assert result == {"action": "persist_ocr_result", "json_url": None, "markdown_url": "https://example.com/result.md"}
+    assert workflow.persist_call[2:] == (None, "https://example.com/result.md")
 
 
 def test_lambda_handler_rejects_empty_markdown_url_for_persist_ocr_result(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_extract_workflow.py
@@ -142,6 +142,8 @@ class _FakeOCRClient:
     # CN: 同上。
     def __init__(self):
         self.polls = 0
+        self.download_json_calls: list[str] = []
+        self.download_markdown_calls: list[str] = []
 
     def submit_job(self, *, payload, key):
         return _Submission(job_id="job-1")
@@ -158,9 +160,11 @@ class _FakeOCRClient:
         )
 
     def download_json_lines(self, json_url):
+        self.download_json_calls.append(json_url)
         return [{"result": {"layoutParsingResults": [{"markdown": {"text": "hello"}, "outputImages": {}}]}}]
 
     def download_markdown(self, markdown_url):
+        self.download_markdown_calls.append(markdown_url)
         return "# Hello\n\nhello"
 
     def download_binary(self, url):
@@ -170,7 +174,11 @@ class _FakeOCRClient:
 class _FakeManifestBuilder:
     # EN: Stand-in for PaddleOCRManifestBuilder returning a fixed manifest.
     # CN: 杩斿洖鍥哄畾 manifest 鐨?PaddleOCRManifestBuilder 鏇胯韩銆?
+    def __init__(self):
+        self.json_lines_calls: list[list[dict] | None] = []
+
     def build_manifest_from_markdown(self, *, source, markdown_text, binary_loader, json_lines=None):
+        self.json_lines_calls.append(json_lines)
         return ChunkManifest(
             source=source,
             doc_type="pdf",
@@ -231,12 +239,17 @@ def test_step_functions_workflow_polls_until_ocr_completes() -> None:
     result = workflow.persist_ocr_result(
         job=ExtractJobMessage(source=source, trace_id="trace-1"),
         processing_state=ObjectStateRecord(**prepared["processing_state"]),
-        json_url=status["json_url"] or "",
+        json_url=status["json_url"],
         markdown_url=status["markdown_url"] or "",
     )
 
     assert result["chunk_count"] == 1
     assert persister.previous_versions == [("v0", "s3://manifest-bucket/manifests/v0.json")]
+    assert workflow._ocr_client.download_json_calls == ["https://example.com/result.jsonl"]
+    assert workflow._ocr_client.download_markdown_calls == ["https://example.com/result.md"]
+    assert workflow._manifest_builder.json_lines_calls == [
+        [{"result": {"layoutParsingResults": [{"markdown": {"text": "hello"}, "outputImages": {}}]}}]
+    ]
 
 
 def test_step_functions_workflow_reuses_ingest_processing_state() -> None:
@@ -277,6 +290,43 @@ def test_step_functions_workflow_reuses_ingest_processing_state() -> None:
     assert state_repo.activate_ingest_state_calls == [(source.document_uri, "v0")]
     assert extract_worker.processing_states[0].previous_version_id == "v0"
     assert extract_worker.processing_states[0].previous_manifest_s3_uri == "s3://manifest-bucket/manifests/v0.json"
+
+
+def test_step_functions_workflow_supports_markdown_only_persist() -> None:
+    """
+    EN: Markdown-only OCR results should persist without requiring JSONL.
+    CN: 仅有 Markdown 的 OCR 结果应可直接持久化，而无需 JSONL。
+    """
+    ocr_client = _FakeOCRClient()
+    manifest_builder = _FakeManifestBuilder()
+    workflow = StepFunctionsExtractWorkflow(
+        extract_worker=_FakeExtractWorker(),
+        result_persister=_FakePersister(),
+        object_state_repo=_FakeObjectStateRepo(),
+        source_repo=_FakeSourceRepo(),
+        ocr_client=ocr_client,
+        manifest_builder=manifest_builder,
+    )
+    source = S3ObjectRef(tenant_id="tenant-a", bucket="bucket-a", key="docs/scan.pdf", version_id="v1")
+    processing_state = ObjectStateRecord(
+        pk=source.object_pk,
+        latest_version_id=source.version_id,
+        latest_sequencer=source.sequencer,
+        extract_status="EXTRACTING",
+        embed_status="PENDING",
+    )
+
+    result = workflow.persist_ocr_result(
+        job=ExtractJobMessage(source=source, trace_id="trace-1"),
+        processing_state=processing_state,
+        json_url=None,
+        markdown_url="https://example.com/result.md",
+    )
+
+    assert result["chunk_count"] == 1
+    assert ocr_client.download_json_calls == []
+    assert ocr_client.download_markdown_calls == ["https://example.com/result.md"]
+    assert manifest_builder.json_lines_calls == [None]
 
 
 def test_step_functions_workflow_marks_failed_state() -> None:

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_chunker.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_chunker.py
@@ -138,3 +138,31 @@ def test_split_markdown_for_embedding_uses_exact_fallback_when_semchunk_is_noop(
     assert all(chunk.token_estimate <= 90 for chunk in chunks)
     assert chunks[0].text.startswith("# Intro")
 
+
+def test_split_markdown_for_embedding_keeps_atomic_blocks_intact_when_packing_sections() -> None:
+    """
+    EN: Atomic blocks stay whole even when the section must be split into multiple chunks.
+    CN: 即使 section 需要拆成多个 chunk，原子 block 也应保持完整。
+    """
+    markdown_text = (
+        "# Intro\n\n"
+        + ("alpha beta gamma delta epsilon zeta eta theta iota kappa " * 8)
+        + "\n\n"
+        "```python\n"
+        "print('hello')\n"
+        "print('world')\n"
+        "```\n\n"
+        + ("lambda mu nu xi omicron pi rho sigma tau upsilon " * 8)
+    )
+
+    chunks = split_markdown_for_embedding(
+        markdown_text,
+        soft_token_target=60,
+        hard_token_limit=120,
+        token_counter=_count_chars,
+        tokenizer=_CharTokenizer(),
+    )
+
+    assert len(chunks) > 1
+    assert all(chunk.token_estimate <= 120 for chunk in chunks)
+    assert any("```python\nprint('hello')\nprint('world')\n```" in chunk.text for chunk in chunks)

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_extractor.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_markdown_extractor.py
@@ -90,6 +90,8 @@ def test_docx_extraction_uses_section_headings_and_tables() -> None:
     assert manifest.metadata["source_format"] == "python-docx"
     assert [chunk.section_path for chunk in manifest.chunks] == [("Intro",), ("Intro", "Details")]
     assert manifest.chunks[0].text.startswith("# Intro")
+    assert all(chunk.metadata["source_format"] == "python-docx" for chunk in manifest.chunks)
+    assert all(chunk.metadata["chunking_strategy"] == "v2_markdown_semchunk" for chunk in manifest.chunks)
     assert "hello world" in manifest.chunks[0].text
     assert "left" in "\n".join(chunk.text for chunk in manifest.chunks)
     assert "right" in "\n".join(chunk.text for chunk in manifest.chunks)
@@ -126,6 +128,8 @@ def test_pptx_extraction_uses_slide_segments() -> None:
     assert manifest.metadata["source_format"] == "python-pptx"
     assert [chunk.section_path for chunk in manifest.chunks] == [("slide-1",), ("slide-2",)]
     assert manifest.chunks[0].text == "Title"
+    assert all(chunk.metadata["source_format"] == "python-pptx" for chunk in manifest.chunks)
+    assert all(chunk.metadata["chunking_strategy"] == "v2_markdown_semchunk" for chunk in manifest.chunks)
     assert "Second" in manifest.chunks[1].text
 
 

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_paddle_manifest_builder.py
@@ -122,3 +122,25 @@ def test_paddle_manifest_builder_recursively_splits_oversized_layout_markdown(mo
     assert manifest.chunks[0].text.startswith("# Intro")
     assert any("```python" in chunk.text for chunk in manifest.chunks)
     assert any(chunk.text.startswith("## Next") for chunk in manifest.chunks)
+
+
+def test_paddle_manifest_builder_accepts_markdown_only_input() -> None:
+    """
+    EN: Paddle manifest builder should persist markdown-only OCR results without JSONL.
+    CN: Paddle manifest builder 应支持仅有 Markdown 的 OCR 结果而不依赖 JSONL。
+    """
+    builder = PaddleOCRManifestBuilder()
+    source = S3ObjectRef(tenant_id="tenant-a", bucket="bucket-a", key="docs/scan.pdf", version_id="v1")
+
+    manifest = builder.build_manifest_from_markdown(
+        source=source,
+        markdown_text="# Intro\n\nhello world",
+        binary_loader=lambda url: (f"binary:{url}".encode("utf-8"), "image/png"),
+        json_lines=None,
+    )
+
+    assert manifest.metadata["raw_json_asset_count"] == 0
+    assert manifest.metadata["layout_markdown_asset_count"] == 1
+    assert manifest.metadata["markdown_asset_count"] == 2
+    assert manifest.metadata["document_markdown_asset_count"] == 1
+    assert manifest.chunks[0].text.startswith("# Intro")

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py
@@ -247,6 +247,56 @@ class _FakeProjectionStateRepo:
         return _Record()
 
 
+class _BatchProjectionStateRepo:
+    # EN: Projection state repo that records batch lookups.
+    # CN: 记录 batch 查询的 projection state repo 替身。
+    def __init__(self) -> None:
+        self.batch_keys: list[tuple[str, str, str]] = []
+
+    def get_states_batch(self, *, keys):
+        self.batch_keys.extend(keys)
+        return {
+            key: _FakeProjectionStateRepo().get_state(
+                object_pk=key[0],
+                version_id=key[1],
+                profile_id=key[2],
+            )
+            for key in keys
+        }
+
+
+def test_query_service_uses_batch_projection_state_reads() -> None:
+    """
+    EN: Query service should batch load projection states when the repository supports it.
+    CN: QueryService 在仓库支持时应批量加载 projection state。
+    """
+    batch_repo = _BatchProjectionStateRepo()
+    service = QueryService(
+        embedding_clients={
+            "gemini-default": _FakeGeminiClient(),
+            "openai-text-small": _FakeOpenAIClient(),
+        },
+        query_profiles=_build_profiles(),
+        vector_repo=_FakeVectorRepo(),
+        manifest_repo=_FakeManifestRepo(),
+        object_state_repo=_FakeObjectStateRepo(),
+        projection_state_repo=batch_repo,
+    )
+
+    result = service.search(
+        query="hello",
+        tenant_id="tenant-a",
+        top_k=5,
+        neighbor_expand=1,
+    )
+
+    assert len(result.results) == 1
+    assert set(batch_repo.batch_keys) == {
+        ("tenant-a#bucket-a#docs%2Fguide.md", "v2", "gemini-default"),
+        ("tenant-a#bucket-a#docs%2Fguide.md", "v1", "gemini-default"),
+    }
+
+
 def _build_profiles():
     return (
         EmbeddingProfile(


### PR DESCRIPTION
## 变更摘要

本 PR 一次性收敛了 Markdown-first 提取链路、runtime 装配和查询路径的几个长期漂移点。核心目标是让 OCR 持久化链路支持 markdown-only 结果，让 md/docx/pptx 统一使用同一套 Markdown-aware chunker，并把 query/embed/ingest 的 repository 装配收敛到共享 bootstrap 层，减少重复 wiring 和测试假设偏差。

- 问题是什么：
  - `extract_persist` / `persist_ocr_result` 仍把 `json_url` 当作必需输入，和 Markdown-first 持久化链路不一致。
  - Markdown chunking 仍可能在 section 级别切碎原子块，md/docx/pptx 的处理路径也不完全一致。
  - runtime composition root 存在重复 repository 装配，query service 的 projection state 读取仍是逐条读取。
  - contract-ci 还引用了已失效的测试文件名。
- 为什么要改：
  - 消除 OCR 结果格式演进带来的链路断点。
  - 统一 chunking 和 runtime wiring，降低维护成本和回归概率。
  - 为 query 的治理状态读取提供更好的批量路径。
- 这次改了什么：
  - 允许 markdown-only persist 输入，`json_url` 变为可选，`markdown_url` 保持必需。
  - 重写 Markdown chunk packing 逻辑，保持原子 block 不被切碎。
  - md/docx/pptx 统一走 Markdown-aware splitter。
  - 抽出 runtime 共享 repository builder，并让 query/embed/ingest 复用。
  - 为 projection state 增加 batch 读取，并补齐相关测试。
  - 更新 `contract-ci.yml` 的测试清单。
- 没有改什么：
  - 没有改 AWS 真实资源拓扑，也没有改默认门禁链的组成。
  - 没有改查询层对 `tenant_id` 的约束模型。
- 对外可见的结果：
  - OCR 持久化现在可以接受 markdown-only 结果。
  - md/docx/pptx 的 chunk 边界更稳定。
  - runtime 和 query 的装配路径更一致。

## 关联 Issue

- 关联 issue：#105-#120
- 关闭关系：Closes #105, Closes #106, Closes #107, Closes #108, Closes #109, Closes #110, Closes #112, Closes #113, Closes #114, Closes #115, Closes #116, Closes #117, Closes #118, Closes #119, Closes #120
- 如果没有关联 issue，请说明原因：不适用

## 变更类型

- [x] 缺陷修复
- [x] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [x] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围

- 受影响的目录：
  - `ocr-service/ocr-pipeline/src/serverless_mcp/extract`
  - `ocr-service/ocr-pipeline/src/serverless_mcp/runtime`
  - `ocr-service/ocr-pipeline/src/serverless_mcp/query`
  - `ocr-service/ocr-pipeline/src/serverless_mcp/storage/projection`
  - `ocr-service/ocr-pipeline/tests/unit/serverless_mcp`
  - `.github/workflows`
- 受影响的模块 / 服务：
  - extract workflow / handlers
  - Markdown chunking
  - runtime bootstrap / query runtime / embed runtime / ingest runtime
  - query service
  - projection state repository
- 受影响的 workflow：
  - `contract-ci.yml`
- 受影响的脚本 / 任务：
  - 无新增脚本
- 受影响的数据结构 / 配置：
  - OCR persist 输入契约
  - projection state batch read 路径
  - contract-ci 测试清单
- 是否影响默认 PR 门禁：
  - 是，修正了 `contract-ci.yml`
- 是否影响部署 / 回滚：
  - 不影响默认部署流程；回滚可通过回退本 PR 完成

## 详细说明

### 1. 主要改动

- 改动点 1：OCR persist 支持 markdown-only 输入。
- 改动点 2：Markdown chunking 改为 block-packed split，避免原子块被切碎。
- 改动点 3：runtime 共享 bootstrap + query projection batch read + contract-ci 清单修复。

### 2. 设计选择

- 为什么采用当前方案：
  - 以最小接口变更完成 Markdown-first 演进，同时保持旧 JSONL 路径兼容。
- 备选方案是什么：
  - 继续强制 JSONL 作为 persist 必需输入，或保留多套 chunking 路径。
- 为什么没有选择备选方案：
  - 会继续放大链路分叉和测试维护成本。

### 3. 兼容性

- 是否向后兼容：
  - 向后兼容，旧 JSONL + Markdown 输入仍可工作。
- 是否需要迁移：
  - 不需要额外数据迁移。
- 是否需要重建索引 / 重新部署 / 重新生成产物：
  - 需要按现有流程重新部署代码；不需要额外索引迁移。
- 是否引入新环境变量 / 新配置项：
  - 未引入新环境变量。

### 4. 代码 / 文件清单

- 新增文件：
  - 无
- 修改文件：
  - 见 PR files 列表
- 删除文件：
  - 无
- 重命名文件：
  - 无

## 验证

### 本地验证

- 执行的命令：
  - `uv run --project ocr-service python -m compileall ocr-service/ocr-pipeline/src/serverless_mcp ocr-service/ocr-pipeline/tests/unit/serverless_mcp`
  - `uv run --project ocr-service pytest`
- 命令输出结论：
  - `compileall` 通过
  - `pytest` 通过，结果为 `323 passed, 2 skipped`
- 相关截图 / 日志 / 链接：
  - 无

### 自动化验证

- [x] 单元测试
- [x] 集成测试
- [x] 静态检查
- [x] 构建检查
- [x] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：
  - `compileall`
  - 全量 `pytest`
  - GitHub Actions 已通过的现有 checks
- 失败项：
  - 无
- 未执行项及原因：
  - 其他外部云侧验证未执行，因本 PR 以可重复的本地/CI 验证为准

## 风险与回滚

- 主要风险：
  - Markdown chunk boundary 变化可能让少量回归测试的期望值变化。
  - runtime 装配收敛如果有遗漏，可能导致某些 Lambda 入口初始化失败。
- 风险缓解方式：
  - 已补齐相关测试并跑过全量 pytest。
- 回滚方式：
  - 直接回退本 PR 或 revert 该提交。
- 回滚后遗留影响：
  - 回滚后恢复旧 JSONL-only 的 persist 行为和旧的 chunking 结果。
- 是否需要灰度：
  - 不需要，当前是代码与测试收敛类变更

## 对业务 / 运维的影响

- 是否影响线上行为：
  - 会，OCR persist 和查询治理路径更稳，但语义保持一致。
- 是否影响部署流程：
  - 不影响部署流程本身。
- 是否影响监控 / 告警：
  - 不新增监控项。
- 是否影响成本 / 性能：
  - query projection state 批量读取有助于降低读放大。
- 是否影响运维手册：
  - 需要在后续文档中持续保持与 Markdown-first 处理链路一致。

## 截图 / 录屏 / 示例

- 截图：
  - 无
- 录屏：
  - 无
- 示例输入：
  - Markdown-only OCR 输出
- 示例输出：
  - 可正常持久化 manifest 和 chunks

## 待确认事项

- [ ] 无

## Reviewer 关注点

- 请重点检查：
  - `extract/workflow.py`、`entrypoints/extract_persist.py`、`extract/handlers/persist.py` 的输入契约变化
  - `markdown_chunker.py` 的 block-packed split 逻辑
  - `query/application.py` 的 projection batch read fallback
  - `contract-ci.yml` 的测试清单是否与实际文件一致
- 请重点验证：
  - Markdown-only persist 路径
  - md/docx/pptx chunk 边界
  - query 结果不被 projection state batching 影响
- 请重点确认：
  - 本 PR 的 issue 关闭范围确实覆盖 #105-#120

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
