### PR TITLE
[fix] 生产部署栈回滚失败自动恢复

### DIFF
--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -130,6 +130,73 @@ print(json.dumps(report, ensure_ascii=False, indent=2))
 PY
 }
 
+collect_rollback_skip_resources() {
+  local stack_name="$1"
+
+  aws cloudformation describe-stack-events --stack-name "$stack_name" --output json | python3 -c '
+from __future__ import annotations
+
+import json
+import sys
+
+payload = json.load(sys.stdin)
+ids: list[str] = []
+seen: set[str] = set()
+for event in payload.get("StackEvents", []):
+    reason = event.get("ResourceStatusReason") or ""
+    if "could not be found" not in reason and "HandlerErrorCode: NotFound" not in reason:
+        continue
+    logical_id = event.get("LogicalResourceId")
+    if logical_id and logical_id not in seen:
+        seen.add(logical_id)
+        ids.append(logical_id)
+print(" ".join(ids))
+'
+}
+
+recover_failed_stack() {
+  local stack_name="$1"
+  local stack_status skip_resources
+
+  stack_status="$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || true)"
+  if [[ "$stack_status" != "UPDATE_ROLLBACK_FAILED" ]]; then
+    return 0
+  fi
+
+  printf '::warning::Stack %s is %s; attempting rollback recovery.\n' "$stack_name" "$stack_status"
+  skip_resources="$(collect_rollback_skip_resources "$stack_name")"
+  if [[ -n "$skip_resources" ]]; then
+    printf '::warning::Skipping CloudFormation resources for %s: %s\n' "$stack_name" "$skip_resources"
+    aws cloudformation continue-update-rollback --stack-name "$stack_name" --resources-to-skip $skip_resources
+  else
+    printf '::warning::No explicit skip list found for %s; retrying rollback without skips.\n' "$stack_name"
+    aws cloudformation continue-update-rollback --stack-name "$stack_name"
+  fi
+
+  local attempts current_status
+  for attempts in {1..60}; do
+    current_status="$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || true)"
+    case "$current_status" in
+      UPDATE_ROLLBACK_COMPLETE|UPDATE_COMPLETE|CREATE_COMPLETE)
+        printf '::notice::Stack %s recovered with status %s.\n' "$stack_name" "$current_status"
+        return 0
+        ;;
+      UPDATE_ROLLBACK_FAILED|UPDATE_ROLLBACK_IN_PROGRESS|UPDATE_IN_PROGRESS|CREATE_IN_PROGRESS|ROLLBACK_IN_PROGRESS|ROLLBACK_FAILED)
+        sleep 10
+        ;;
+      "")
+        printf '::warning::Stack %s disappeared while recovering; continuing with deploy.\n' "$stack_name"
+        return 0
+        ;;
+      *)
+        sleep 10
+        ;;
+    esac
+  done
+
+  die "Timed out waiting for CloudFormation stack recovery: $stack_name"
+}
+
 main() {
   local arg release_tag confirm_release_tag config_path deploy_report
   release_tag="main"
@@ -171,10 +238,15 @@ main() {
   cd "$ROOT"
 
   REPO_NAME="$(json_read "$CONFIG_PATH" repo_name)"
+  STACK_PREFIX="$(json_read "$CONFIG_PATH" name_prefix)"
   export REPO_NAME
   export MCP_CDK_ASSET_DIR="$ASSET_DIR"
   export MCP_PIPELINE_CONFIG_PATH="$CONFIG_PATH"
   export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+  recover_failed_stack "$STACK_PREFIX-foundation"
+  recover_failed_stack "$STACK_PREFIX-compute"
+  recover_failed_stack "$STACK_PREFIX-api"
 
   if gh release view "$release_tag" >/dev/null 2>&1; then
     download_release_assets


### PR DESCRIPTION
## 变更摘要

这次 PR 解决生产部署在 `mcp-doc-pipeline-prod-compute` 进入 `UPDATE_ROLLBACK_FAILED` 后无法继续发布的问题。根因是 CloudFormation 在回滚阶段仍然引用已经不存在的 Lambda 物理资源，导致 `cdk deploy` 直接失败。现在在正式部署入口里加入了回滚恢复逻辑，会先检查相关栈状态，再对缺失资源执行 `continue-update-rollback`，最后继续正常部署。这个改动只影响生产部署脚本，不改 Lambda 业务逻辑，也不改基础设施资源定义本身。对外可见结果是：同类堆栈损坏场景下，部署流程可以自动恢复并继续执行。

## 关联 Issue

- 关联 issue：无单独 issue，本次作为紧急部署修复直接处理
- 关闭关系：无
- 如果是跨仓库引用，请写明完整链接：无
- 如果没有关联 issue，请说明原因：这次是生产部署回滚失败的即时修复，先直接恢复部署链路

## 变更类型

请选择所有适用项：

- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [ ] 配置
- [ ] 测试
- [ ] 维护 / 清理

## 影响范围

说明这次改动会影响哪些层、模块、流程或外部接口。

- 受影响的目录：`scripts/`
- 受影响的模块 / 服务：生产部署入口 `scripts/prod-deploy.sh`
- 受影响的 workflow：`Prod Deploy`
- 受影响的脚本 / 任务：`scripts/prod-deploy.sh`
- 受影响的数据结构 / 配置：无新增配置项
- 是否影响默认 PR 门禁：否
- 是否影响部署 / 回滚：是，增加了回滚恢复步骤

## 详细说明

按“改动点 -> 目的 -> 结果”的顺序逐条说明。

### 1. 主要改动

- 改动点 1：在部署前增加 CloudFormation 栈状态检查
- 改动点 2：在 `UPDATE_ROLLBACK_FAILED` 时自动从 stack events 中提取缺失资源并调用 `continue-update-rollback`
- 改动点 3：恢复完成后再继续执行原有的 release 下载 / 资产构建 / `cdk deploy`

### 2. 设计选择

- 为什么采用当前方案：这是对现有部署入口侵入最小的修复方式，能直接处理损坏栈
- 备选方案是什么：手工在控制台修复堆栈，或者重建整套基础设施
- 为什么没有选择备选方案：人工恢复不可重复，重建成本高且风险更大

### 3. 兼容性

- 是否向后兼容：是
- 是否需要迁移：否
- 是否需要重建索引 / 重新部署 / 重新生成产物：否
- 是否引入新环境变量 / 新配置项：否

### 4. 代码 / 文件清单

- 新增文件：无
- 修改文件：`scripts/prod-deploy.sh`
- 删除文件：无
- 重命名文件：无

## 验证

请明确列出实际执行过的验证步骤，而不是只写“已测试”。

### 本地验证

- 执行的命令：`git diff --check`
- 命令输出结论：通过，无空白或补丁格式问题
- 相关截图 / 日志 / 链接：无

### 自动化验证

- [ ] 单元测试
- [ ] 集成测试
- [x] 静态检查
- [x] 构建检查
- [ ] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：`git diff --check`
- 失败项：无
- 未执行项及原因：真实 AWS 回滚验证未执行，因为需要线上环境

## 风险与回滚

说明这次 PR 最可能带来的风险，以及如果需要回退，应该怎么回退。

- 主要风险：自动回滚恢复可能会让部署流程额外等待
- 风险缓解方式：只在 `UPDATE_ROLLBACK_FAILED` 时触发，正常路径不受影响
- 回滚方式：回退 `scripts/prod-deploy.sh` 到上一版提交
- 回滚后遗留影响：无额外持久状态
- 是否需要灰度：不需要

## 对业务 / 运维的影响

- 是否影响线上行为：仅影响部署恢复路径，不改运行时业务逻辑
- 是否影响部署流程：是，部署前会自动尝试恢复损坏栈
- 是否影响监控 / 告警：否
- 是否影响成本 / 性能：基本无影响
- 是否影响运维手册：建议补充一条“堆栈损坏时会自动恢复”的说明

## 截图 / 录屏 / 示例

如果改动涉及 UI、文档排版、流程演示或输出格式，请在这里补充。

- 截图：无
- 录屏：无
- 示例输入：生产栈进入 `UPDATE_ROLLBACK_FAILED`
- 示例输出：部署脚本先恢复栈，再继续 `cdk deploy`

## 待确认事项

如果还有未决问题，请在这里列出，并标明由谁确认。

- [ ] 待确认 1：真实 AWS 环境里 `continue-update-rollback` 的恢复耗时
- [ ] 待确认 2：是否需要在运维文档中补充恢复说明
- [ ] 待确认 3：是否要把相同恢复逻辑扩展到更多生产栈

## Reviewer 关注点

告诉 reviewer 重点看哪里，减少来回沟通。

- 请重点检查：部署脚本只在损坏栈场景介入，没有破坏正常路径
- 请重点验证：缺失 Lambda 资源是否能被正确提取为 skip list
- 请重点确认：PR 未修改 Lambda 业务代码和基础设施定义

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出