### PR TITLE
fix: fail prod deploy after skipped rollback resources

### DIFF
--- a/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -38,6 +38,7 @@ def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     assert "npm ci --prefix infra/cdk" in script_text
     assert "npm --prefix infra/cdk run deploy" in script_text
     assert "prod-deploy-report.json" in script_text
+    assert "Restore the missing stack resources before re-running prod deploy." in script_text
 
 
 def test_destroy_workflow_uses_cdk_destroy_with_placeholder_assets() -> None:

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -179,6 +179,9 @@ recover_failed_stack() {
     case "$current_status" in
       UPDATE_ROLLBACK_COMPLETE|UPDATE_COMPLETE|CREATE_COMPLETE)
         printf '::notice::Stack %s recovered with status %s.\n' "$stack_name" "$current_status"
+        if [[ -n "$skip_resources" ]]; then
+          die "CloudFormation recovery for $stack_name required skipping resources: $skip_resources. Restore the missing stack resources before re-running prod deploy."
+        fi
         return 0
         ;;
       UPDATE_ROLLBACK_FAILED|UPDATE_ROLLBACK_IN_PROGRESS|UPDATE_IN_PROGRESS|CREATE_IN_PROGRESS|ROLLBACK_IN_PROGRESS|ROLLBACK_FAILED)


### PR DESCRIPTION
## 变更摘要

这次 PR 只做一件事：当 `scripts/prod-deploy.sh` 在 CloudFormation 回滚恢复时必须跳过资源时，立即停止后续 `cdk deploy`。这样可以避免已经缺失的 Lambda 资源再次触发同一类 `UPDATE_ROLLBACK_FAILED` / `NotFound` 失败。

- 问题是什么：prod deploy 在恢复失败栈后仍继续部署，导致 CI 重复撞上缺失 Lambda 资源。
- 为什么要改：恢复时如果已经需要 `--resources-to-skip`，说明当前栈状态不适合继续自动发布。
- 这次改了什么：在恢复成功后增加硬失败提示，并补了一条回归测试断言。
- 没有改什么：没有改 CDK 模板、资源命名或发布产物打包逻辑。
- 对外可见的结果：遇到漂移/缺失资源时，deploy 会更早失败并明确提示先恢复 CloudFormation 资源。

## 关联 Issue

- 关联 issue：无直接关联 issue；这是针对 GitHub Actions 中 prod deploy 失败日志的直接修复。
- 关闭关系：无
- 如果是跨仓库引用，请写明完整链接：无
- 如果没有关联 issue，请说明原因：这次修复是从 CI 失败日志直接定位并处理的最小变更，没有额外的 issue 编号。

## 变更类型

请选择所有适用项：

- [x] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [ ] 配置
- [x] 测试
- [ ] 维护 / 清理

## 影响范围

说明这次改动会影响哪些层、模块、流程或外部接口。

- 受影响的目录：`scripts/`、`ocr-service/tools/ci/tests/deployment_helpers/`
- 受影响的模块 / 服务：prod deploy 入口脚本、部署回归测试
- 受影响的 workflow：`Prod Deploy` 间接受影响
- 受影响的脚本 / 任务：`scripts/prod-deploy.sh`
- 受影响的数据结构 / 配置：无
- 是否影响默认 PR 门禁：否
- 是否影响部署 / 回滚：是，遇到需要 skip 的 rollback recovery 时会提前中止部署

## 详细说明

按“改动点 -> 目的 -> 结果”的顺序逐条说明。

### 1. 主要改动

- 改动点 1：在 `recover_failed_stack` 中检测恢复是否依赖 `--resources-to-skip`。
- 改动点 2：如果恢复过程中跳过了资源，则在恢复完成后直接失败并给出明确提示。
- 改动点 3：补充测试断言，防止后续回归把这个保护逻辑删掉。

### 2. 设计选择

- 为什么采用当前方案：这是最小、最安全的处理方式，避免在已知不一致的 CloudFormation 状态下继续发布。
- 备选方案是什么：尝试自动重建缺失 Lambda 或继续无条件 deploy。
- 为什么没有选择备选方案：自动重建会扩大变更面，且这次失败的根因是栈漂移，不适合在部署脚本里隐式修复。

### 3. 兼容性

- 是否向后兼容：是；只有在恢复阶段需要跳过资源时才改变行为。
- 是否需要迁移：不需要代码迁移，但需要先恢复缺失的 CloudFormation 资源后再重新部署。
- 是否需要重建索引 / 重新部署 / 重新生成产物：不需要。
- 是否引入新环境变量 / 新配置项：否。

### 4. 代码 / 文件清单

- 新增文件：无
- 修改文件：`scripts/prod-deploy.sh`、`ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py`
- 删除文件：无
- 重命名文件：无

## 验证

请明确列出实际执行过的验证步骤，而不是只写“已测试”。

### 本地验证

- 执行的命令：`uv run --project ocr-service python -m pytest -q ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py`
- 命令输出结论：`3 passed`
- 相关截图 / 日志 / 链接：无

### 自动化验证

- [x] 单元测试
- [ ] 集成测试
- [ ] 静态检查
- [ ] 构建检查
- [ ] workflow / CI 检查
- [ ] 其他：

### 验证结果

- 通过项：部署脚本回归测试通过
- 失败项：无
- 未执行项及原因：集成测试 / workflow 检查未执行，因为这次只修改了部署入口脚本和文本级回归断言

## 风险与回滚

说明这次 PR 最可能带来的风险，以及如果需要回退，应该怎么回退。

- 主要风险：当 CloudFormation 恢复需要跳过资源时，prod deploy 会更早中止。
- 风险缓解方式：错误信息明确指向需要先恢复的缺失资源，避免重复失败。
- 回滚方式：回退本 PR 的两个文件修改。
- 回滚后遗留影响：无。
- 是否需要灰度：否

## 对业务 / 运维的影响

- 是否影响线上行为：仅在部署失败恢复路径上影响行为。
- 是否影响部署流程：是，会在不安全的栈状态下提前失败。
- 是否影响监控 / 告警：否。
- 是否影响成本 / 性能：否。
- 是否影响运维手册：建议补充“先恢复缺失 CloudFormation 资源，再重跑 prod deploy”的操作说明。

## 截图 / 录屏 / 示例

如果改动涉及 UI、文档排版、流程演示或输出格式，请在这里补充。

- 截图：无
- 录屏：无
- 示例输入：CloudFormation stack 已进入 `UPDATE_ROLLBACK_FAILED`，且恢复时需要 skip 资源
- 示例输出：部署脚本在恢复完成后直接报错并提示先恢复缺失资源

## 待确认事项

如果还有未决问题，请在这里列出，并标明由谁确认。

- [x] 待确认 1：无需额外 issue
- [x] 待确认 2：无需额外配置变更
- [x] 待确认 3：无需额外部署产物变更

## Reviewer 关注点

告诉 reviewer 重点看哪里，减少来回沟通。

- 请重点检查：`recover_failed_stack` 在 skip resources 场景下是否会提前停止部署
- 请重点验证：错误提示是否足够明确，能帮助运维先恢复缺失资源
- 请重点确认：测试断言是否覆盖了这条保护逻辑

## 提交前自检

- [x] PR 正文已按 `.github/pull_request_template.md` 填写完整
- [x] 第一部分已写清楚问题、方案和结果
- [x] 已在 PR 前部以普通文本写明 `Closes #123` / `Fixes #123` / 对应跨仓库引用，且未放进反引号、代码块或引用块
- [x] 变更类型和影响范围已标明
- [x] 验证结果已写明通过、失败和未执行项
- [x] 风险与回滚方案已写明
- [x] 已在提交后回看一次 GitHub 上实际显示的标题、正文和模板字段，确认没有乱码、错码、字符丢失或明显编码异常
- [x] 若涉及代码变更，已补齐测试说明
- [x] 若涉及 workflow / 配置 / 文档，已同步说明相关影响
- [x] 若关联 sub issue，已说明层级关系
- [x] 若需要 reviewer 特别关注的点，已提前列出
