### PR TITLE
fix: tighten prod deploy rollback recovery

### DIFF
--- a/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
+++ b/ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py
@@ -39,6 +39,9 @@ def test_prod_deploy_workflow_uses_cdk_deploy_from_release_assets() -> None:
     assert "npm --prefix infra/cdk run deploy" in script_text
     assert "prod-deploy-report.json" in script_text
     assert "Restore the missing stack resources before re-running prod deploy." in script_text
+    assert "UPDATE_FAILED" in script_text
+    assert "DELETE_FAILED" in script_text
+    assert "CloudFormation continue-update-rollback failed for" in script_text
 
 
 def test_destroy_workflow_uses_cdk_destroy_with_placeholder_assets() -> None:

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -142,7 +142,10 @@ import sys
 payload = json.load(sys.stdin)
 ids: list[str] = []
 seen: set[str] = set()
+eligible_statuses = {"UPDATE_FAILED", "DELETE_FAILED"}
 for event in payload.get("StackEvents", []):
+    if event.get("ResourceStatus") not in eligible_statuses:
+        continue
     reason = event.get("ResourceStatusReason") or ""
     if "could not be found" not in reason and "HandlerErrorCode: NotFound" not in reason:
         continue
@@ -167,10 +170,14 @@ recover_failed_stack() {
   skip_resources="$(collect_rollback_skip_resources "$stack_name")"
   if [[ -n "$skip_resources" ]]; then
     printf '::warning::Skipping CloudFormation resources for %s: %s\n' "$stack_name" "$skip_resources"
-    aws cloudformation continue-update-rollback --stack-name "$stack_name" --resources-to-skip $skip_resources
+    if ! aws cloudformation continue-update-rollback --stack-name "$stack_name" --resources-to-skip $skip_resources; then
+      die "CloudFormation continue-update-rollback failed for $stack_name. Repair the skipped resources before rerunning prod deploy."
+    fi
   else
     printf '::warning::No explicit skip list found for %s; retrying rollback without skips.\n' "$stack_name"
-    aws cloudformation continue-update-rollback --stack-name "$stack_name"
+    if ! aws cloudformation continue-update-rollback --stack-name "$stack_name"; then
+      die "CloudFormation continue-update-rollback failed for $stack_name. Inspect stack events before rerunning prod deploy."
+    fi
   fi
 
   local attempts current_status


### PR DESCRIPTION
## 概要
- 收紧 `scripts/prod-deploy.sh` 的 CloudFormation rollback recovery：只从 `UPDATE_FAILED` / `DELETE_FAILED` 事件里收集可跳过资源，并在 `continue-update-rollback` 失败时返回明确错误。
- 补充对应回归断言，覆盖失败路径和显式错误文案。

## 验证
- `python -m pytest ocr-service/tools/ci/tests/deployment_helpers/test_cdk_workflows.py`

Closes #131