### PR TITLE
[task] 删除冗余 security_scope 契约残留

### DIFF
--- a/ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/auth.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/auth.py
@@ -11,10 +11,6 @@ from typing import Any, Iterator
 from serverless_mcp.runtime.config import load_settings
 
 REQUEST_TENANT_ID: ContextVar[str | None] = ContextVar("mcp_gateway_request_tenant_id", default=None)
-REQUEST_SECURITY_SCOPE: ContextVar[tuple[str, ...]] = ContextVar(
-    "mcp_gateway_request_security_scope",
-    default=(),
-)
 
 
 def get_request_tenant_id() -> str | None:
@@ -25,14 +21,6 @@ def get_request_tenant_id() -> str | None:
     return REQUEST_TENANT_ID.get()
 
 
-def get_request_security_scope() -> tuple[str, ...]:
-    """
-    EN: Read the normalized security scope from the current request context.
-    CN: 从当前请求上下文读取规范化后的 security scope。
-    """
-    return REQUEST_SECURITY_SCOPE.get()
-
-
 @contextmanager
 def push_request_context(event: dict[str, Any]) -> Iterator[None]:
     """
@@ -40,11 +28,9 @@ def push_request_context(event: dict[str, Any]) -> Iterator[None]:
     CN: 在单次 Lambda 调用期间填充请求身份上下文变量。
     """
     token = REQUEST_TENANT_ID.set(extract_request_tenant_id(event))
-    scope_token = REQUEST_SECURITY_SCOPE.set(extract_request_security_scope(event))
     try:
         yield
     finally:
-        REQUEST_SECURITY_SCOPE.reset(scope_token)
         REQUEST_TENANT_ID.reset(token)
 
 
@@ -61,21 +47,6 @@ def extract_request_tenant_id(event: dict[str, Any]) -> str | None:
     if isinstance(claim_value, str) and claim_value.strip():
         return claim_value.strip()
     return None
-
-
-def extract_request_security_scope(event: dict[str, Any]) -> tuple[str, ...]:
-    """
-    EN: Extract and normalize security scope claims from an API Gateway event.
-    CN: 从 API Gateway 事件中提取并规范化 security scope 声明。
-    """
-    authorizer_claims = _extract_authorizer_claims(event)
-    if not authorizer_claims:
-        return ()
-
-    scope_values: list[str] = []
-    for key in ("security_scope", "scope", "scopes", "cognito:groups"):
-        scope_values.extend(_coerce_scope_values(authorizer_claims.get(key)))
-    return tuple(dict.fromkeys(scope_values))
 
 
 def resolve_effective_tenant_id(
@@ -111,7 +82,7 @@ def resolve_effective_tenant_id(
 def _extract_authorizer_claims(event: dict[str, Any]) -> dict[str, Any]:
     """
     EN: Extract authorizer claims from API Gateway REST or HTTP API payloads.
-    CN: 从 API Gateway REST 或 HTTP API 载荷中提取 authorizer claims。
+    CN: 从 API Gateway REST 或 HTTP API 负载中提取 authorizer claims。
     """
     if not isinstance(event, dict):
         return {}
@@ -136,21 +107,3 @@ def _extract_authorizer_claims(event: dict[str, Any]) -> dict[str, Any]:
     for source in claims_sources:
         merged.update(source)
     return merged
-
-
-def _coerce_scope_values(value: object) -> list[str]:
-    """
-    EN: Coerce a scope claim into a deduplicated list of strings.
-    CN: 将 scope 声明转换为去重后的字符串列表。
-    """
-    if isinstance(value, str):
-        tokens = [item.strip() for item in value.replace(",", " ").replace(";", " ").split()]
-        return [token for token in tokens if token]
-    if isinstance(value, (list, tuple, set)):
-        values: list[str] = []
-        for item in value:
-            if isinstance(item, str) and item.strip():
-                values.append(item.strip())
-        return values
-    return []
-

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/services/retrieval_service.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/services/retrieval_service.py
@@ -5,7 +5,7 @@ CN: 查询侧 MCP tools 的检索服务辅助函数。
 from __future__ import annotations
 
 from serverless_mcp.core.serialization import coerce_bounded_int, coerce_required_str, serialize_query_response
-from serverless_mcp.mcp_gateway.auth import get_request_security_scope, resolve_effective_tenant_id
+from serverless_mcp.mcp_gateway.auth import resolve_effective_tenant_id
 from serverless_mcp.mcp_gateway.schemas import dump_json_payload
 
 
@@ -47,7 +47,6 @@ def search_documents(
         tenant_id=resolved_tenant_id,
         top_k=bounded_top_k,
         neighbor_expand=bounded_neighbor_expand,
-        security_scope=get_request_security_scope(),
         doc_type=doc_type,
         key=key,
     )

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/query/access.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/query/access.py
@@ -44,39 +44,6 @@ def metadata_is_truthy(metadata: dict[str, object], field: str) -> bool:
     return False
 
 
-def metadata_security_scope(metadata: dict[str, object]) -> tuple[str, ...]:
-    """
-    EN: Normalize vector metadata security_scope into a comparable tuple.
-    CN: 将向量元数据中的 security_scope 规范化为可比较元组。
-    """
-    value = metadata.get("security_scope")
-    if isinstance(value, str):
-        tokens = [item.strip() for item in value.replace(",", " ").replace(";", " ").split()]
-        return tuple(dict.fromkeys(token for token in tokens if token))
-    if isinstance(value, (list, tuple, set)):
-        scopes: list[str] = []
-        for item in value:
-            if not isinstance(item, str):
-                continue
-            token = item.strip()
-            if token and token not in scopes:
-                scopes.append(token)
-        return tuple(scopes)
-    return ()
-
-
-def security_scope_allows_access(candidate_scopes: tuple[str, ...], request_scopes: tuple[str, ...]) -> bool:
-    """
-    EN: Allow public vectors or vectors whose scope intersects the request scope.
-    CN: 允许公开向量，或其 scope 与请求 scope 有交集的向量。
-    """
-    if not candidate_scopes:
-        return True
-    if not request_scopes:
-        return False
-    return bool(set(candidate_scopes) & set(request_scopes))
-
-
 def is_queryable_object_state(
     object_state: ObjectStateRecord | None,
     source,
@@ -125,7 +92,7 @@ def record_degraded_profile(
 ) -> None:
     """
     EN: Record a degraded profile entry with deduplication by (profile_id, stage, manifest_s3_uri).
-    CN: 按 (profile_id, stage, manifest_s3_uri) 去重后记录一个 degraded profile 条目。
+    CN: 按 (profile_id, stage, manifest_s3_uri) 去重后记录一条 degraded profile。
     """
     key = (profile_id, stage, manifest_s3_uri)
     if key in degraded_keys:

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/query/application.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/query/application.py
@@ -32,10 +32,8 @@ from serverless_mcp.query.access import (
     is_queryable_object_state,
     is_queryable_projection_state,
     metadata_is_truthy,
-    metadata_security_scope,
     record_degraded_profile,
     sanitize_result_metadata,
-    security_scope_allows_access,
 )
 from serverless_mcp.query.fusion import (
     RankedCandidate,
@@ -100,7 +98,6 @@ class QueryService:
         tenant_id: str,
         top_k: int = 10,
         neighbor_expand: int = 1,
-        security_scope: tuple[str, ...] = (),
         doc_type: str | None = None,
         key: str | None = None,
     ) -> QueryResponse:
@@ -118,11 +115,10 @@ class QueryService:
             return QueryResponse(query=query, results=[])
 
         logger.info(
-            "search_documents.start query_len=%s top_k=%s neighbor_expand=%s security_scope_count=%s enabled_profiles=%s",
+            "search_documents.start query_len=%s top_k=%s neighbor_expand=%s enabled_profiles=%s",
             len(query),
             top_k,
             neighbor_expand,
-            len(security_scope),
             len(enabled_profiles),
         )
         metadata_filter = build_metadata_filter(
@@ -223,9 +219,6 @@ class QueryService:
         for candidate in sorted_candidates:
             metadata = sanitize_result_metadata(candidate.match.metadata)
             source = candidate.source
-            candidate_security_scope = metadata_security_scope(candidate.match.metadata)
-            if not security_scope_allows_access(candidate_security_scope, security_scope):
-                continue
             vector_is_latest = metadata_is_truthy(candidate.match.metadata, "is_latest")
             object_state = state_cache.get(source.object_pk)
             if object_state is None:

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/query/request.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/query/request.py
@@ -21,14 +21,13 @@ class TenantIdConflictError(PermissionError):
 class RemoteQueryRequest:
     """
     EN: Normalized query request resolved from MCP parameters and application settings.
-    CN: 由 MCP 参数和应用设置解析得到的规范化查询请求。
+    CN: 由 MCP 参数和应用配置解析得到的规范化查询请求。
     """
 
     query: str
     tenant_id: str
     top_k: int
     neighbor_expand: int
-    security_scope: tuple[str, ...] = ()
     doc_type: str | None = None
     key: str | None = None
 
@@ -43,7 +42,6 @@ def build_remote_query_request(
     doc_type: str | None,
     key: str | None,
     settings: Settings | None = None,
-    request_security_scope: tuple[str, ...] | None = None,
 ) -> RemoteQueryRequest:
     """
     EN: Validate the public query contract before the remote MCP handler calls the core service.
@@ -60,7 +58,6 @@ def build_remote_query_request(
             minimum=0,
             maximum=active_settings.query_max_neighbor_expand,
         ),
-        security_scope=_normalize_security_scope(request_security_scope),
         doc_type=doc_type.strip() if isinstance(doc_type, str) and doc_type.strip() else None,
         key=key.strip() if isinstance(key, str) and key.strip() else None,
     )
@@ -69,10 +66,10 @@ def build_remote_query_request(
 def _resolve_tenant_id(tenant_id: str | None, *, request_tenant_id: str | None, settings: Settings) -> str:
     """
     EN: Bind the query tenant to the authenticated claim when present and only permit matching caller overrides.
-    CN: 当认证声明存在时，将查询租户绑定到认证租户，并且只允许与之相同的调用方覆盖值。
+    CN: 当认证声明存在时，将查询租户绑定到认证租户，并且只允许相同的调用方覆盖值。
 
     EN: Anonymous fallback is only honored when unauthenticated queries are explicitly enabled and the configured default is not the shared lookup tenant.
-    CN: 只有在显式启用匿名查询且配置的默认值不是共享 lookup tenant 时，才接受匿名回退。
+    CN: 只有在显式启用匿名查询且配置默认值不是共享 lookup tenant 时，才接受匿名回退。
     """
     explicit_tenant_id = tenant_id.strip() if isinstance(tenant_id, str) and tenant_id.strip() else None
     authenticated_tenant_id = (
@@ -94,21 +91,3 @@ def _resolve_tenant_id(tenant_id: str | None, *, request_tenant_id: str | None, 
         if default_tenant_id and default_tenant_id != "lookup":
             return default_tenant_id
     raise ValueError("tenant_id is required")
-
-
-def _normalize_security_scope(security_scope: tuple[str, ...] | None) -> tuple[str, ...]:
-    """
-    EN: Normalize security scope values into a stable tuple for query-time authorization.
-    CN: 将 security scope 规范化为稳定元组，用于查询时授权。
-    """
-    if not security_scope:
-        return ()
-    normalized: list[str] = []
-    for item in security_scope:
-        if not isinstance(item, str):
-            continue
-        value = item.strip()
-        if not value or value in normalized:
-            continue
-        normalized.append(value)
-    return tuple(normalized)

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py
@@ -165,7 +165,6 @@ class _RestrictedVectorRepo:
                     "key": "docs/secret.md",
                     "version_id": "v2",
                     "is_latest": True,
-                    "security_scope": ["team-a"],
                     "manifest_s3_uri": "s3://manifest-bucket/manifests/example.json",
                     "chunk_id": "chunk#000002",
                 },
@@ -515,10 +514,10 @@ def test_query_service_prefers_projection_records_over_full_manifest_load() -> N
     assert manifest_repo.projection_calls == [("tenant-a#bucket-a#docs%2Fguide.md", "v2")]
 
 
-def test_query_service_filters_restricted_vectors_by_security_scope() -> None:
+def test_query_service_does_not_filter_vectors_by_security_scope() -> None:
     """
-    EN: Query service filters restricted vectors unless the request carries a matching security scope.
-    CN: QueryService 会过滤受限向量，除非请求携带匹配的 security scope。
+    EN: Query service does not use security_scope as a request-time authorization filter.
+    CN: QueryService 不再把 security_scope 当作请求时的授权过滤条件。
     """
     service = QueryService(
         embedding_clients={"gemini-default": _FakeGeminiClient()},
@@ -529,24 +528,14 @@ def test_query_service_filters_restricted_vectors_by_security_scope() -> None:
         projection_state_repo=_FakeProjectionStateRepo(),
     )
 
-    denied = service.search(
+    results = service.search(
         query="hello",
         tenant_id="tenant-a",
         top_k=5,
         neighbor_expand=0,
-    )
-    allowed = service.search(
-        query="hello",
-        tenant_id="tenant-a",
-        top_k=5,
-        neighbor_expand=0,
-        security_scope=("team-a",),
     )
 
-    assert [result.key for result in denied.results] == [
-        "gemini-default#tenant-a#bucket-a#docs/public.md#v2#chunk#000003",
-    ]
-    assert [result.key for result in allowed.results] == [
+    assert [result.key for result in results.results] == [
         "gemini-default#tenant-a#bucket-a#docs/secret.md#v2#chunk#000002",
         "gemini-default#tenant-a#bucket-a#docs/public.md#v2#chunk#000003",
     ]

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py
@@ -369,7 +369,6 @@ def test_lambda_handler_initialize_tools_list_and_call(monkeypatch) -> None:
     assert content["query"] == "hello"
     assert content["results"][0]["delivery"]["url"].startswith("https://cdn.example.com/")
     assert context.query_service.calls[0]["tenant_id"] == "tenant-a"
-    assert context.query_service.calls[0]["security_scope"] == ()
 
 
 def test_lambda_handler_defaults_search_documents_to_lookup_tenant(monkeypatch) -> None:


### PR DESCRIPTION
Closes #154

## 变更摘要
删除 query/auth/request 链路里冗余的 `security_scope` 请求上下文和授权过滤逻辑，保留必要的元数据脱敏，但不再把它当作查询时的访问控制条件。

## 关联 Issue
- 关联 issue: #154
- 关闭关系: Closes #154

## 变更类型
- [ ] 缺陷修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 安全加固
- [ ] CI / workflow
- [ ] 配置
- [x] 测试
- [x] 维护 / 清理

## 影响范围
- `ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/auth.py`
- `ocr-service/ocr-pipeline/src/serverless_mcp/mcp_gateway/services/retrieval_service.py`
- `ocr-service/ocr-pipeline/src/serverless_mcp/query/request.py`
- `ocr-service/ocr-pipeline/src/serverless_mcp/query/application.py`
- `ocr-service/ocr-pipeline/src/serverless_mcp/query/access.py`
- `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_query_service.py`
- `ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_remote_mcp_smoke.py`

## 详细说明
### 1. 主要改动
- 移除请求上下文中的 `security_scope` 提取与保存。
- 移除 remote MCP 到 query service 的 `security_scope` 透传。
- 移除 query service 内部按 `security_scope` 过滤向量的判断分支。
- 删除过时的“请求携带 security_scope 时才放行”的测试语义。

### 2. 设计选择
- 继续保留结果元数据脱敏，避免内部字段直接对外暴露。
- 不再引入新的授权维度，查询边界只保留 `tenant_id`。

### 3. 兼容性
- 不向后兼容旧的 `security_scope` 查询参数。
- 不涉及迁移、重建索引或新增配置项。

### 4. 文件清单
- 修改文件: 7 个
- 新增文件: 无
- 删除文件: 无

## 验证
### 本地验证
- 执行命令: `uv run --project ocr-service pytest`
- 命令结论: `342 passed, 2 skipped`

### 自动化验证
- [x] 单元测试
- [ ] 集成测试
- [ ] 静态检查
- [ ] 构建检查
- [ ] workflow / CI 检查

### 验证结果
- 通过项: 全量 pytest
- 失败项: 无
- 未执行项及原因: 集成测试、静态检查、构建检查已由现有门禁覆盖/不在本次手工范围内

## 风险与回滚
- 主要风险: 旧调用方如果仍传 `security_scope`，该参数不再参与查询授权。
- 风险缓解方式: 保留 `tenant_id` 约束与结果元数据脱敏。
- 回滚方式: revert commit `d9b6bed`。
- 回滚后遗留影响: 会重新恢复冗余授权分支与旧测试语义。
- 是否需要灰度: 否。

## 对业务 / 运维的影响
- 是否影响线上行为: 会移除 `security_scope` 查询授权语义。
- 是否影响部署流程: 否。
- 是否影响监控 / 告警: 否。
- 是否影响成本 / 性能: 轻微减少请求处理开销。
- 是否影响运维手册: 否。

## 待确认事项
- [x] 不需要补充其他任务
- [x] 不需要再拆子 issue
- [x] 不需要额外说明文档

## Reviewer 关注点
- 请重点检查 query/auth 请求链路是否已经不再依赖 `security_scope`。
- 请重点确认保留的元数据脱敏不会影响现有结果格式。
- 请重点确认测试断言已经反映当前契约。