### PR TITLE
[task] 补齐 cleanup 可观测性与契约收口

### DIFF
--- a/docs/query-contract-and-runtime-prereqs.md
+++ b/docs/query-contract-and-runtime-prereqs.md
@@ -35,3 +35,10 @@
 - 如果业务确实需要匿名访问，必须显式开启 `allow_unauthenticated_query=true`，并把 `remote_mcp_default_tenant_id` 配成明确的公开 tenant，不要继续依赖 `lookup` 作为默认回退。
 - Embed 侧旧版本向量清理由独立的 Step Functions cleanup workflow 负责，运行时需要显式注入 `VECTOR_CLEANUP_STATE_MACHINE_ARN`。
 - 查询侧优先走 chunk projection 读取，只有投影缺失或回源失败时才读取完整 manifest。
+## 清理可观测性
+
+- 旧版本向量清理由独立的 Step Functions cleanup workflow 执行，embed 侧只负责生成 cleanup plan 并发起编排。
+- cleanup dispatch 会输出结构化 metric `embed.cleanup.dispatch`，`status` 取值为 `started`、`succeeded` 或 `failed`。
+- 失败时会额外带上 `error_type`，并写回 `object_state.last_error`，用于排障和回放。
+- cleanup execution name 由 cleanup plan 的确定性 payload 派生，相同计划重复触发时应得到相同 execution name，便于幂等去重。
+- cleanup dispatch 成功后，不等待删除完成；真正的删除重试、补偿和幂等判断由 cleanup workflow 自己负责。

--- a/ocr-service/ocr-pipeline/src/serverless_mcp/embed/application.py
+++ b/ocr-service/ocr-pipeline/src/serverless_mcp/embed/application.py
@@ -14,7 +14,7 @@ from urllib.parse import quote
 from botocore.exceptions import ClientError
 
 from serverless_mcp.embed.asset_source import EmbedAssetSource
-from serverless_mcp.runtime.observability import emit_trace
+from serverless_mcp.runtime.observability import emit_metric, emit_trace
 from serverless_mcp.domain.embedding_schema import validate_embedding_job_message
 from serverless_mcp.domain.models import (
     EmbeddingJobMessage,
@@ -311,6 +311,13 @@ class EmbedWorker:
                 error_type=type(exc).__name__,
                 error_message=str(exc),
             )
+            emit_metric(
+                "embed.cleanup.dispatch",
+                status="failed",
+                profile_id=job.profile_id,
+                previous_version_id=job.previous_version_id or "",
+                error_type=type(exc).__name__,
+            )
             self._object_state_repo.mark_embed_cleanup_failed(job.source, str(exc))
 
     def _start_cleanup_execution(self, cleanup_plan: VectorCleanupPlan) -> None:
@@ -329,10 +336,22 @@ class EmbedWorker:
             "profile_id": cleanup_plan.profile_id,
         }
         execution_name = self._build_cleanup_execution_name(payload)
+        emit_metric(
+            "embed.cleanup.dispatch",
+            status="started",
+            profile_id=cleanup_plan.profile_id,
+            previous_version_id=cleanup_plan.previous_version_id,
+        )
         self._stepfunctions_client.start_execution(
             stateMachineArn=self._cleanup_state_machine_arn,
             name=execution_name,
             input=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        )
+        emit_metric(
+            "embed.cleanup.dispatch",
+            status="succeeded",
+            profile_id=cleanup_plan.profile_id,
+            previous_version_id=cleanup_plan.previous_version_id,
         )
 
     def _build_cleanup_execution_name(self, payload: dict[str, object]) -> str:

--- a/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_worker.py
+++ b/ocr-service/ocr-pipeline/tests/unit/serverless_mcp/test_embed_worker.py
@@ -4,6 +4,7 @@ CN: 鍚屼笂銆?
 """
 
 import json
+from dataclasses import asdict
 
 import pytest
 
@@ -18,6 +19,7 @@ from serverless_mcp.domain.models import (
     ExtractedChunk,
     ObjectStateRecord,
     S3ObjectRef,
+    VectorCleanupPlan,
 )
 from serverless_mcp.storage.paths import optimize_source_file_name
 
@@ -356,7 +358,7 @@ def _build_single_profile_worker(
     )
 
 
-def test_embed_worker_writes_vectors_marks_done_and_records_previous_version_cleanup() -> None:
+def test_embed_worker_writes_vectors_marks_done_and_records_previous_version_cleanup(monkeypatch) -> None:
     """
     EN: Embed worker writes vectors marks done and cleans previous version artifacts.
     CN: 妤犲矁鐦?embed worker writes vectors marks done and cleans previous version artifacts閵?
@@ -367,6 +369,12 @@ def test_embed_worker_writes_vectors_marks_done_and_records_previous_version_cle
     object_state_repo = _FakeObjectStateRepo()
     manifest_repo = _FakeManifestRepo()
     stepfunctions_client = _FakeStepFunctionsClient()
+    metrics = []
+    monkeypatch.setattr(
+        embed_application_module,
+        "emit_metric",
+        lambda metric_name, value=1, **dimensions: metrics.append((metric_name, value, dimensions)),
+    )
     worker = _build_single_profile_worker(
         object_state_repo=object_state_repo,
         vector_repo=vector_repo,
@@ -420,6 +428,19 @@ def test_embed_worker_writes_vectors_marks_done_and_records_previous_version_cle
         "gemini-default#tenant-a#bucket-a#docs%2Fguide.pdf#v0#chunk#000001",
         "gemini-default#tenant-a#bucket-a#docs%2Fguide.pdf#v0#asset#000001",
     ]
+    assert metrics == [
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "started", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "succeeded", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+    ]
+
     assert manifest_repo.delete_calls == [(source.document_uri, "v0", "s3://manifest-bucket/manifests/v0.json")]
 
 
@@ -890,7 +911,7 @@ def test_embed_worker_requires_projection_state_for_multiple_profiles() -> None:
         raise AssertionError("multiple write profiles should require projection state governance")
 
 
-def test_embed_worker_keeps_success_when_previous_version_cleanup_fails() -> None:
+def test_embed_worker_keeps_success_when_previous_version_cleanup_fails(monkeypatch) -> None:
     """
     EN: Embed worker keeps success when previous version cleanup fails.
     CN: 妤犲矁鐦?embed worker keeps success when previous version cleanup fails閵?
@@ -900,6 +921,12 @@ def test_embed_worker_keeps_success_when_previous_version_cleanup_fails() -> Non
     object_state_repo = _FakeObjectStateRepo()
     manifest_repo = _FakeManifestRepo()
     stepfunctions_client = _FailingStepFunctionsClient()
+    metrics = []
+    monkeypatch.setattr(
+        embed_application_module,
+        "emit_metric",
+        lambda metric_name, value=1, **dimensions: metrics.append((metric_name, value, dimensions)),
+    )
     worker = _build_single_profile_worker(
         object_state_repo=object_state_repo,
         vector_repo=_FakeVectorRepo(),
@@ -931,3 +958,85 @@ def test_embed_worker_keeps_success_when_previous_version_cleanup_fails() -> Non
     assert object_state_repo.done == [source.document_uri]
     assert object_state_repo.cleanup_failed == [(source.document_uri, "cleanup dispatch failed")]
     assert len(stepfunctions_client.executions) == 1
+    assert metrics == [
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "started", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {
+                "status": "failed",
+                "profile_id": "gemini-default",
+                "previous_version_id": "v0",
+                "error_type": "RuntimeError",
+            },
+        ),
+    ]
+def test_embed_cleanup_dispatch_is_deterministic_for_identical_plans(monkeypatch) -> None:
+    """
+    EN: Cleanup dispatch uses a deterministic execution name for identical cleanup plans.
+    CN: 相同 cleanup plan 使用确定性的 execution name。
+    """
+    worker = _build_single_profile_worker(
+        object_state_repo=_FakeObjectStateRepo(),
+        vector_repo=_FakeVectorRepo(),
+        manifest_repo=_FakeManifestRepo(),
+        stepfunctions_client=_FakeStepFunctionsClient(),
+    )
+    cleanup_plan = VectorCleanupPlan(
+        vector_bucket_name="vector-bucket",
+        vector_index_name="index-gemini",
+        keys=("gemini-default#tenant-a#bucket-a#docs%2Fguide.pdf#v0#chunk#000001",),
+        object_pk="tenant-a#bucket-a#docs/guide.pdf",
+        previous_version_id="v0",
+        profile_id="gemini-default",
+        manifest_s3_uri="s3://manifest-bucket/manifests/example.json",
+        previous_manifest_s3_uri="s3://manifest-bucket/manifests/v0.json",
+        requested_at="2026-04-01T00:00:00Z",
+    )
+
+    metrics = []
+    monkeypatch.setattr(
+        embed_application_module,
+        "emit_metric",
+        lambda metric_name, value=1, **dimensions: metrics.append((metric_name, value, dimensions)),
+    )
+
+    worker._start_cleanup_execution(cleanup_plan)  # noqa: SLF001
+    worker._start_cleanup_execution(cleanup_plan)  # noqa: SLF001
+
+    first_execution, second_execution = worker._stepfunctions_client.executions  # noqa: SLF001
+    assert first_execution["name"] == second_execution["name"]
+    assert first_execution["input"] == second_execution["input"]
+    assert json.loads(first_execution["input"]) == {
+        "cleanup_target": {**asdict(cleanup_plan), "keys": list(cleanup_plan.keys)},
+        "requested_at": cleanup_plan.requested_at,
+        "object_pk": cleanup_plan.object_pk,
+        "previous_version_id": cleanup_plan.previous_version_id,
+        "profile_id": cleanup_plan.profile_id,
+    }
+    assert metrics == [
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "started", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "succeeded", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "started", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+        (
+            "embed.cleanup.dispatch",
+            1,
+            {"status": "succeeded", "profile_id": "gemini-default", "previous_version_id": "v0"},
+        ),
+    ]


### PR DESCRIPTION
Closes #156

## 变更
- 为 previous-version cleanup dispatch 增加结构化 metric，覆盖 started / succeeded / failed
- 补充 cleanup execution 的确定性幂等回归测试
- 在运行契约文档里补充 cleanup workflow 的可观测性口径

## 验证
- uv run --project ocr-service pytest
- 结果：343 passed, 2 skipped