### PR TITLE
[chore] 改用组织级 PR 模板子模块并移除本地模板

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule ".github/pull_request_template.md"]
+	path = .github/pull_request_template.md
+	url = https://github.com/owokit/organization-pr-template
+	branch = main


### PR DESCRIPTION
Closes #171

## 变更摘要
- 删除仓库内本地 PR 模板文件。
- 将 `https://github.com/owokit/organization-pr-template` 作为 submodule 接入到 `.github/pull_request_template.md`，并固定 `branch = main`。

## 验证
- `git submodule status --recursive`
- `git status --short`
- `git diff --cached --stat`
- `python ai/scripts/sync-ai.py`