### PR TITLE
重建测试系统：边界驱动测试、CDK 合约与 CI 门禁

### DIFF
--- a/.github/workflows/aws-smoke.yml
+++ b/.github/workflows/aws-smoke.yml
@@ -1,0 +1,199 @@
+# EN: Nightly and manual AWS smoke that validates OIDC-based deployment, discovery, and ingest start boundaries.
+# CN: 通过 OIDC 部署、discovery 和 ingest 启动边界进行夜间与手动 AWS smoke 验证。
+name: AWS Smoke
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-smoke-${{ github.event.release.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    # EN: Deploy the minimal stack set, exercise the public discovery endpoint, and start one ingest execution.
+    # CN: 部署最小栈集合，验证公开 discovery endpoint，并启动一次 ingest 执行。
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_SMOKE_ROLE_ARN: ${{ vars.AWS_SMOKE_ROLE_ARN }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up runtime
+        uses: ./.github/actions/setup-runtime
+        with:
+          setup-node: 'true'
+          setup-python: 'true'
+
+      - name: Sync Python tooling
+        run: |
+          set -euo pipefail
+          uv sync --locked --project ocr-service
+
+      - name: Install CDK dependencies
+        working-directory: infra/cdk
+        run: |
+          set -euo pipefail
+          npm ci
+
+      - name: Configure AWS credentials with OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_SMOKE_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Capture AWS account id
+        run: |
+          set -euo pipefail
+          AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID" >> "$GITHUB_ENV"
+
+      - name: Export CDK bootstrap account
+        run: |
+          set -euo pipefail
+          echo "CDK_DEFAULT_ACCOUNT=$AWS_ACCOUNT_ID" >> "$GITHUB_ENV"
+
+      - name: Deploy smoke baseline stacks
+        working-directory: infra/cdk
+        run: |
+          set -euo pipefail
+          npm run deploy -- --outputs-file ../../aws-smoke-outputs.json
+
+      - name: Resolve smoke outputs and derive ingest lambda name
+        id: smoke-outputs
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          repo_root = Path.cwd()
+          config = json.loads((repo_root / 'infra' / 'pipeline-config.json').read_text(encoding='utf-8'))
+          outputs = json.loads((repo_root / 'aws-smoke-outputs.json').read_text(encoding='utf-8'))
+          account = os.environ.get('AWS_ACCOUNT_ID') or ''
+          region = os.environ.get('AWS_REGION') or ''
+          suffix = f'{account}-{region}' if config.get('name_suffix') == 'auto' else str(config.get('name_suffix') or '')
+          ingest_name = config['resource_names']['ingest_lambda']
+          if suffix:
+              ingest_name = f'{ingest_name}-{suffix}'
+          foundation_key = next(key for key in outputs if key.endswith('-foundation'))
+          api_key = next(key for key in outputs if key.endswith('-api'))
+          foundation = outputs[foundation_key]
+          api = outputs[api_key]
+          smoke = {
+              'source_bucket': foundation['SourceBucketName'],
+              'remote_mcp_api_url': api['RemoteMcpApiUrl'],
+              'ingest_lambda_name': ingest_name,
+          }
+          (repo_root / 'aws-smoke-resolved.json').write_text(json.dumps(smoke, ensure_ascii=False, indent=2), encoding='utf-8')
+          print(json.dumps(smoke, ensure_ascii=False, indent=2))
+          PY
+
+      - name: Upload a minimal smoke document
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python <<'PY'
+          from __future__ import annotations
+
+          import json
+          from pathlib import Path
+          import subprocess
+          
+          repo_root = Path.cwd()
+          smoke = json.loads((repo_root / 'aws-smoke-resolved.json').read_text(encoding='utf-8'))
+          smoke_doc = repo_root / 'aws-smoke-minimal.md'
+          smoke_doc.write_text('# Smoke document\n\nThis document verifies the live ingest upload boundary.\n', encoding='utf-8')
+          subprocess.run([
+              'aws', 's3', 'cp', str(smoke_doc), f"s3://{smoke['source_bucket']}/smoke/aws-smoke-minimal.md"
+          ], check=True)
+          print(smoke['source_bucket'])
+          PY
+
+      - name: Invoke ingest lambda and verify execution start
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python <<'PY'
+          from __future__ import annotations
+
+          import json
+          import subprocess
+          from pathlib import Path
+
+          repo_root = Path.cwd()
+          smoke = json.loads((repo_root / 'aws-smoke-resolved.json').read_text(encoding='utf-8'))
+          event = {
+              'Records': [
+                  {
+                      'eventVersion': '2.1',
+                      'eventSource': 'aws:s3',
+                      'eventName': 'ObjectCreated:Put',
+                      's3': {
+                          'bucket': {'name': smoke['source_bucket']},
+                          'object': {
+                              'key': 'smoke/aws-smoke-minimal.md',
+                              'versionId': 'live-smoke-v1',
+                              'sequencer': '001',
+                          },
+                      },
+                  }
+              ]
+          }
+          payload = repo_root / 'aws-smoke-event.json'
+          response = repo_root / 'aws-smoke-response.json'
+          payload.write_text(json.dumps(event, ensure_ascii=False), encoding='utf-8')
+          subprocess.run([
+              'aws', 'lambda', 'invoke',
+              '--function-name', smoke['ingest_lambda_name'],
+              '--payload', f'file://{payload}',
+              str(response),
+          ], check=True)
+          result = json.loads(response.read_text(encoding='utf-8'))
+          if result.get('started_count', 0) < 1:
+              raise SystemExit(f'Ingest lambda did not start an execution: {result!r}')
+          if result.get('batchItemFailures'):
+              raise SystemExit(f'Ingest lambda reported failures for the smoke document: {result!r}')
+          print(json.dumps(result, ensure_ascii=False, indent=2))
+          PY
+
+      - name: Probe the remote MCP discovery endpoint
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python <<'PY'
+          from __future__ import annotations
+
+          import json
+          import subprocess
+          from pathlib import Path
+
+          repo_root = Path.cwd()
+          smoke = json.loads((repo_root / 'aws-smoke-resolved.json').read_text(encoding='utf-8'))
+          discovery_url = smoke['remote_mcp_api_url'].rstrip('/') + '/mcp'
+          response = subprocess.run(['curl', '-fsS', discovery_url], check=True, capture_output=True, text=True)
+          document = json.loads(response.stdout)
+          if document.get('endpoint') != '/mcp':
+              raise SystemExit(f'Unexpected discovery document: {document!r}')
+          if document.get('protocolVersion') != '2024-11-05':
+              raise SystemExit(f'Unexpected protocolVersion: {document!r}')
+          print(json.dumps(document, ensure_ascii=False, indent=2))
+          PY
+
+      - name: Cleanup smoke resources
+        if: always()
+        working-directory: infra/cdk
+        run: |
+          set -euo pipefail
+          npm run destroy

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -25,7 +25,7 @@ jobs:
       # EN: Use the same repository snapshot that PR reviewers inspect.
       # CN: 使用和 PR 审查一致的仓库快照。
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/local-integration-ci.yml
+++ b/.github/workflows/local-integration-ci.yml
@@ -28,12 +28,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - scenario: storage_roundtrip
-            report: local-integration-storage-roundtrip-report.json
-          - scenario: aws_roundtrip
-            report: local-integration-aws-roundtrip-report.json
+          - scenario: ingest_stubbed_aws
+            report: local-integration-ingest-stubbed-aws-report.json
+          - scenario: emulator_roundtrip
+            report: local-integration-emulator-roundtrip-report.json
           - scenario: sam_job_status
             report: local-integration-sam-job-status-report.json
+          - scenario: remote_mcp_frontdoor
+            report: local-integration-remote-mcp-report.json
           - scenario: stepfunctions_local
             report: local-integration-stepfunctions-report.json
           - scenario: vector_backend
@@ -73,7 +75,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -283,15 +285,99 @@ jobs:
             -e SFN_MOCK_CONFIG=/home/StepFunctionsLocal/MockConfigFile.json \
             amazon/aws-stepfunctions-local
 
-      - name: Run storage roundtrip scenario
-        id: storage_roundtrip
-        if: matrix.scenario == 'storage_roundtrip'
-        run: uv run --project ocr-service python -m pytest -q ocr-service/ocr-pipeline/tests/integration/test_hosted_runner_storage_roundtrip.py --maxfail=1
+      - name: Run ingest stubbed AWS scenario
+        id: ingest_stubbed_aws
+        if: matrix.scenario == 'ingest_stubbed_aws'
+        run: uv run --project ocr-service python -m pytest -q ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py --maxfail=1
 
-      - name: Run AWS roundtrip scenario
-        id: aws_roundtrip
-        if: matrix.scenario == 'aws_roundtrip'
-        run: uv run --project ocr-service python -m pytest -q ocr-service/ocr-pipeline/tests/integration/test_hosted_runner_aws_roundtrip.py --maxfail=1
+      - name: Run emulator roundtrip scenario
+        id: emulator_roundtrip
+        if: matrix.scenario == 'emulator_roundtrip'
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python <<'PY'
+          from __future__ import annotations
+
+          import os
+          import uuid
+
+          from botocore.exceptions import ClientError
+
+          from serverless_mcp.runtime.aws_clients import build_aws_client
+
+          region = os.environ.get('TEST_AWS_REGION', 'us-east-1')
+          s3_bucket = os.environ['TEST_S3_BUCKET']
+          object_state_table = os.environ['TEST_OBJECT_STATE_TABLE']
+          manifest_index_table = os.environ['TEST_MANIFEST_INDEX_TABLE']
+          queue_name = os.environ.get('TEST_SQS_QUEUE_NAME', 'local-roundtrip-queue')
+
+          s3_client = build_aws_client('s3', region_name=region)
+          dynamodb_client = build_aws_client('dynamodb', region_name=region)
+          sqs_client = build_aws_client('sqs', region_name=region)
+
+          try:
+              s3_client.create_bucket(Bucket=s3_bucket)
+          except ClientError as exc:
+              code = str(exc.response.get('Error', {}).get('Code') or '')
+              if code not in {'BucketAlreadyOwnedByYou', 'BucketAlreadyExists'}:
+                  raise
+          try:
+              s3_client.put_bucket_versioning(
+                  Bucket=s3_bucket,
+                  VersioningConfiguration={'Status': 'Enabled'},
+              )
+          except ClientError:
+              pass
+
+          s3_client.put_object(Bucket=s3_bucket, Key='checks/local-roundtrip.txt', Body=b'local roundtrip', ContentType='text/plain')
+          roundtrip_object = s3_client.get_object(Bucket=s3_bucket, Key='checks/local-roundtrip.txt')
+          if roundtrip_object['Body'].read() != b'local roundtrip':
+              raise SystemExit('S3 emulator roundtrip failed')
+
+          existing_tables = set(dynamodb_client.list_tables().get('TableNames') or [])
+          if object_state_table not in existing_tables:
+              dynamodb_client.create_table(
+                  TableName=object_state_table,
+                  KeySchema=[{'AttributeName': 'pk', 'KeyType': 'HASH'}],
+                  AttributeDefinitions=[
+                      {'AttributeName': 'pk', 'AttributeType': 'S'},
+                      {'AttributeName': 'record_type', 'AttributeType': 'S'},
+                  ],
+                  GlobalSecondaryIndexes=[
+                      {
+                          'IndexName': 'lookup-record-type-index',
+                          'KeySchema': [{'AttributeName': 'record_type', 'KeyType': 'HASH'}],
+                          'Projection': {'ProjectionType': 'ALL'},
+                      }
+                  ],
+                  BillingMode='PAY_PER_REQUEST',
+              )
+          if manifest_index_table not in existing_tables:
+              dynamodb_client.create_table(
+                  TableName=manifest_index_table,
+                  KeySchema=[
+                      {'AttributeName': 'pk', 'KeyType': 'HASH'},
+                      {'AttributeName': 'sk', 'KeyType': 'RANGE'},
+                  ],
+                  AttributeDefinitions=[
+                      {'AttributeName': 'pk', 'AttributeType': 'S'},
+                      {'AttributeName': 'sk', 'AttributeType': 'S'},
+                  ],
+                  BillingMode='PAY_PER_REQUEST',
+              )
+          dynamodb_client.put_item(TableName=object_state_table, Item={'pk': {'S': 'local#item'}, 'latest_version_id': {'S': 'v1'}})
+          stored = dynamodb_client.get_item(TableName=object_state_table, Key={'pk': {'S': 'local#item'}})
+          if stored.get('Item', {}).get('latest_version_id', {}).get('S') != 'v1':
+              raise SystemExit('DynamoDB emulator roundtrip failed')
+
+          queue_url = sqs_client.create_queue(QueueName=f"{queue_name}-{uuid.uuid4().hex[:8]}")["QueueUrl"]
+          sqs_client.send_message(QueueUrl=queue_url, MessageBody='local message')
+          message_response = sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
+          messages = message_response.get('Messages') or []
+          if len(messages) != 1 or messages[0]['Body'] != 'local message':
+              raise SystemExit('SQS emulator roundtrip failed')
+          sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=messages[0]['ReceiptHandle'])
+          PY
 
       - name: Run SAM job status smoke
         id: sam_job_status
@@ -557,7 +643,7 @@ jobs:
         if: always()
         env:
           SCENARIO_NAME: ${{ matrix.scenario }}
-          SCENARIO_OUTCOME: ${{ steps.storage_roundtrip.outcome || steps.aws_roundtrip.outcome || steps.sam_job_status.outcome || steps.remote_mcp_frontdoor.outcome || steps.stepfunctions_local.outcome || steps.vector_backend.outcome }}
+          SCENARIO_OUTCOME: ${{ steps.ingest_stubbed_aws.outcome || steps.emulator_roundtrip.outcome || steps.sam_job_status.outcome || steps.remote_mcp_frontdoor.outcome || steps.stepfunctions_local.outcome || steps.vector_backend.outcome }}
           REPORT_PATH: ${{ matrix.report }}
         run: |
           set -euo pipefail
@@ -572,8 +658,10 @@ jobs:
           outcome = os.environ.get("SCENARIO_OUTCOME", "success")
           report_path = Path(os.environ["REPORT_PATH"])
           artifacts_by_scenario = {
-              "storage_roundtrip": [],
-              "aws_roundtrip": [],
+              "ingest_stubbed_aws": [
+                  "ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py",
+              ],
+              "emulator_roundtrip": [],
               "sam_job_status": [
                   ".github/ci/sam-local-staging",
                   ".github/ci/sam-job-status-template.yaml",

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,154 @@
+# EN: Fast PR validation for tests, packaging smoke, CDK synth contract, and workflow hygiene.
+# CN: 用于测试、打包冒烟、CDK synth 契约和 workflow 卫生检查的快速 PR 校验。
+name: PR Validate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-lint:
+    # EN: Verify workflow inventory, shared runtime wiring, and basic shell safety before running heavier checks.
+    # CN: 在运行更重的检查之前，先验证 workflow 清单、共享 runtime 绑定和基础 shell 安全。
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up runtime
+        uses: ./.github/actions/setup-runtime
+        with:
+          setup-python: 'true'
+
+      - name: Sync Python tooling
+        run: |
+          set -euo pipefail
+          uv sync --locked --project ocr-service
+
+      - name: Validate workflow inventory and runtime wiring
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python ocr-service/tools/ci/validate_workflows.py
+
+      - name: Check workflow shell safety patterns
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python <<'PY'
+          from __future__ import annotations
+
+          from pathlib import Path
+          import re
+
+          workflows = Path('.github/workflows')
+          forbidden = {
+              r'curl\s+[^\n]*\|\s*bash': 'curl | bash',
+              r'wget\s+[^\n]*\|\s*bash': 'wget | bash',
+              r'rm\s+-rf\s+/': 'rm -rf /',
+              r'\beval\s+': 'eval',
+          }
+          violations: list[str] = []
+          for path in sorted(workflows.glob('*.yml')):
+              text = path.read_text(encoding='utf-8')
+              for pattern, label in forbidden.items():
+                  if re.search(pattern, text):
+                      violations.append(f'{path.name}: {label}')
+          if violations:
+              raise SystemExit('Unsafe workflow shell pattern(s) found:\n' + '\n'.join(violations))
+          print('Workflow shell safety scan passed')
+          PY
+
+  python-boundary-tests:
+    # EN: Run the new Python unit, contract, and local integration layers without live AWS or network access.
+    # CN: 在不接触真实 AWS 和网络的情况下运行新的 Python unit、contract 和 local integration 分层。
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up runtime
+        uses: ./.github/actions/setup-runtime
+        with:
+          setup-python: 'true'
+
+      - name: Sync Python tooling
+        run: |
+          set -euo pipefail
+          uv sync --locked --project ocr-service
+
+      - name: Run boundary-driven Python tests
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python -m pytest -q \
+            ocr-service/ocr-pipeline/tests/unit/test_runtime_config.py \
+            ocr-service/ocr-pipeline/tests/unit/test_runtime_aws_clients.py \
+            ocr-service/ocr-pipeline/tests/unit/test_runtime_bootstrap.py \
+            ocr-service/ocr-pipeline/tests/unit/test_entrypoint_ingest.py \
+            ocr-service/ocr-pipeline/tests/unit/test_runtime_ingest.py \
+            ocr-service/ocr-pipeline/tests/unit/test_mcp_gateway_handler.py \
+            ocr-service/ocr-pipeline/tests/unit/test_lambda_wrappers_registry.py \
+            ocr-service/ocr-pipeline/tests/unit/test_package_lambda_unit.py \
+            ocr-service/ocr-pipeline/tests/contract/test_public_entrypoints_contract.py \
+            ocr-service/ocr-pipeline/tests/contract/test_lambda_package_smoke.py \
+            ocr-service/ocr-pipeline/tests/contract/test_remote_mcp_discovery_contract.py \
+            ocr-service/ocr-pipeline/tests/contract/test_environment_contract.py \
+            ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py \
+            -m 'not requires_network and not requires_aws' \
+            --maxfail=1
+
+  lambda-packaging-smoke:
+    # EN: Run a narrow packaging smoke lane so ZIP composition failures are isolated from broader test failures.
+    # CN: 运行窄范围的打包冒烟泳道，把 ZIP 组成失败与更广泛的测试失败隔离开来。
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up runtime
+        uses: ./.github/actions/setup-runtime
+        with:
+          setup-python: 'true'
+
+      - name: Sync Python tooling
+        run: |
+          set -euo pipefail
+          uv sync --locked --project ocr-service
+
+      - name: Run packaging smoke tests
+        run: |
+          set -euo pipefail
+          uv run --project ocr-service python -m pytest -q \
+            ocr-service/ocr-pipeline/tests/unit/test_package_lambda_unit.py \
+            ocr-service/ocr-pipeline/tests/contract/test_lambda_package_smoke.py \
+            --maxfail=1
+
+  cdk-synth-contract:
+    # EN: Verify the CDK app can synthesize and that the key stack outputs remain stable.
+    # CN: 验证 CDK app 能够 synth，并且关键 stack 输出保持稳定。
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up runtime
+        uses: ./.github/actions/setup-runtime
+        with:
+          setup-node: 'true'
+
+      - name: Install CDK dependencies
+        working-directory: infra/cdk
+        run: |
+          set -euo pipefail
+          npm ci
+
+      - name: Run CDK contract tests
+        working-directory: infra/cdk
+        run: |
+          set -euo pipefail
+          npm test

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -36,7 +36,7 @@ jobs:
       # EN: Check out the exact repository snapshot under review.
       # CN: 拉取当前审查中的仓库快照。
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/docs/open-source-ci-strategy.md
+++ b/docs/open-source-ci-strategy.md
@@ -17,6 +17,7 @@
 
 其中：
 
+- `PR Validate` 负责 PR 上的快速边界验证，覆盖 workflow lint、Python boundary tests、Lambda packaging smoke 和 CDK synth contract。
 - `Workflow Sanity` 负责 workflow 语法、tabs、actionlint 和清单一致性。
 - `Guardrails` 负责 secret shape 和中文乱码扫描。
 - `Logic CI` 负责代码逻辑层校验。
@@ -24,6 +25,18 @@
 - `Contract CI` 负责 provider、序列化和存储契约。
 - `Local Integration CI` 负责本地编排集成验证。
 - `Package Release` 只在上游成功后发布产物。
+
+### `pr-validate.yml`
+
+- 展示名：`PR Validate`
+- 触发：`pull_request`、`workflow_dispatch`
+- 职责：快速验证 workflow lint、Python boundary tests、Lambda packaging smoke 和 CDK synth contract
+
+### `aws-smoke.yml`
+
+- 展示名：`AWS Smoke`
+- 触发：`schedule`、`release`、`workflow_dispatch`
+- 职责：在真实 AWS 上验证 OIDC 部署、应用 discovery 和 ingest 启动边界
 
 ## Workflow 清单
 
@@ -86,7 +99,7 @@
 
 - 展示名：`Local Integration CI`
 - 触发：`pull_request`、`workflow_run`、`workflow_dispatch`
-- 职责：在本地仿真环境里串联整条运行链路
+- 职责：在本地仿真环境里串联整条运行链路，验证 hosted runner 上可重复的 emulator 组合与 ingest stub roundtrip
 
 ### `codeql.yml`
 

--- a/infra/cdk/package.json
+++ b/infra/cdk/package.json
@@ -5,7 +5,8 @@
     "synth": "cdk --app \"npx ts-node bin/app.ts\" synth",
     "diff": "cdk --app \"npx ts-node bin/app.ts\" diff",
     "deploy": "cdk --app \"npx ts-node bin/app.ts\" deploy --all --method direct --concurrency 3 --require-approval never --progress events",
-    "destroy": "cdk --app \"npx ts-node bin/app.ts\" destroy --all --force --progress events"
+    "destroy": "cdk --app \"npx ts-node bin/app.ts\" destroy --all --force --progress events",
+    "test": "node --require ts-node/register/transpile-only --test test/app.synth.test.ts test/compute-stack.contract.test.ts"
   },
   "dependencies": {
     "aws-cdk": "^2.1113.0",

--- a/infra/cdk/test/app.synth.test.ts
+++ b/infra/cdk/test/app.synth.test.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+
+declare const require: any;
+declare const __dirname: string;
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const cdk = require('aws-cdk-lib');
+const { ApiStack } = require('../lib/api-stack');
+const { ComputeStack } = require('../lib/compute-stack');
+const { FoundationStack } = require('../lib/foundation-stack');
+const { applyNameSuffix, loadPipelineConfig } = require('../lib/config');
+
+function buildAssembly(account: string, region: string) {
+  const app = new cdk.App();
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const pipelineConfig = loadPipelineConfig(repoRoot, 'infra/pipeline-config.json');
+  applyNameSuffix(pipelineConfig, account, region);
+
+  const stackEnvironment = {
+    env: {
+      account,
+      region,
+    },
+  };
+
+  const foundationStack = new FoundationStack(app, `${pipelineConfig.name_prefix}-foundation`, {
+    ...stackEnvironment,
+    pipelineConfig,
+  });
+  const computeStack = new ComputeStack(app, `${pipelineConfig.name_prefix}-compute`, {
+    ...stackEnvironment,
+    pipelineConfig,
+    artifactDir: 'ocr-service/ocr-pipeline/dist',
+    deploymentInputs: {},
+    allowPlaceholderAssets: true,
+  });
+  const apiStack = new ApiStack(app, `${pipelineConfig.name_prefix}-api`, {
+    ...stackEnvironment,
+    pipelineConfig,
+  });
+
+  (computeStack as any).addDependency(foundationStack);
+  (apiStack as any).addDependency(computeStack);
+
+  const assembly = app.synth();
+  return { assembly, foundationStack, computeStack, apiStack, pipelineConfig };
+}
+
+test('app synth fails fast when CDK_DEFAULT_ACCOUNT and CDK_DEFAULT_REGION are missing', () => {
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const appPath = path.join(__dirname, '../bin/app.ts');
+  const result = childProcess.spawnSync(
+    process.execPath,
+    ['-r', 'ts-node/register/transpile-only', appPath],
+    {
+      cwd: path.join(repoRoot, 'infra/cdk'),
+      env: {
+        ...process.env,
+        CDK_DEFAULT_ACCOUNT: '',
+        CDK_DEFAULT_REGION: '',
+        AWS_ACCOUNT_ID: '',
+        AWS_REGION: '',
+        MCP_ALLOW_PLACEHOLDER_ASSETS: 'true',
+      },
+      encoding: 'utf8',
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stderr}${result.stdout}`, /CDK_DEFAULT_ACCOUNT and CDK_DEFAULT_REGION must be set/);
+});
+
+test('app synth emits the public stack outputs and stable stack artifact names', () => {
+  const { assembly, foundationStack, computeStack, apiStack, pipelineConfig } = buildAssembly('111111111111', 'us-east-1');
+
+  const foundationArtifact: any = assembly.getStackArtifact((foundationStack as any).artifactId);
+  const computeArtifact: any = assembly.getStackArtifact((computeStack as any).artifactId);
+  const apiArtifact: any = assembly.getStackArtifact((apiStack as any).artifactId);
+
+  const foundationTemplate = JSON.parse(fs.readFileSync(path.join(assembly.directory, foundationArtifact.templateFile), 'utf8'));
+  const computeTemplate = JSON.parse(fs.readFileSync(path.join(assembly.directory, computeArtifact.templateFile), 'utf8'));
+  const apiTemplate = JSON.parse(fs.readFileSync(path.join(assembly.directory, apiArtifact.templateFile), 'utf8'));
+
+  assert.equal(foundationTemplate.Outputs.VectorBucketName.Value, pipelineConfig.resource_names.vector_bucket);
+  assert.ok(foundationTemplate.Outputs.SourceBucketName.Value.Ref);
+  assert.ok(foundationTemplate.Outputs.ManifestBucketName.Value.Ref);
+  assert.ok(computeTemplate.Outputs.StateMachineArn.Value);
+  assert.ok(computeTemplate.Outputs.CleanupStateMachineArn.Value);
+  assert.ok(computeTemplate.Outputs.RemoteMcpLambdaArn.Value);
+  assert.ok(apiTemplate.Outputs.RemoteMcpApiUrl.Value);
+
+  assert.deepEqual(
+    computeArtifact.dependencies.map((dependency: any) => dependency.id),
+    [foundationArtifact.id],
+  );
+  assert.deepEqual(
+    apiArtifact.dependencies.map((dependency: any) => dependency.id),
+    [computeArtifact.id],
+  );
+});
+
+export {};

--- a/infra/cdk/test/app.synth.test.ts
+++ b/infra/cdk/test/app.synth.test.ts
@@ -93,9 +93,10 @@ test('app synth emits the public stack outputs and stable stack artifact names',
   assert.ok(computeTemplate.Outputs.RemoteMcpLambdaArn.Value);
   assert.ok(apiTemplate.Outputs.RemoteMcpApiUrl.Value);
 
+  const computeDependencyIds = computeArtifact.dependencies.map((dependency: any) => dependency.id);
   assert.deepEqual(
-    computeArtifact.dependencies.map((dependency: any) => dependency.id),
-    [foundationArtifact.id],
+    computeDependencyIds,
+    [foundationArtifact.id, `${computeArtifact.id}.assets`],
   );
   assert.deepEqual(
     apiArtifact.dependencies.map((dependency: any) => dependency.id),

--- a/infra/cdk/test/compute-stack.contract.test.ts
+++ b/infra/cdk/test/compute-stack.contract.test.ts
@@ -51,7 +51,9 @@ test('compute stack exposes only the contract outputs needed by deploy and smoke
   assert.ok(template.Outputs.StateMachineArn.Value);
   assert.ok(template.Outputs.CleanupStateMachineArn.Value);
   assert.ok(template.Outputs.RemoteMcpLambdaArn.Value);
-  assert.equal(artifact.dependencies.length, 1);
+  const dependencyIds = artifact.dependencies.map((dependency: any) => dependency.id);
+  assert.equal(dependencyIds.length, 2);
+  assert.ok(dependencyIds.some((id: string) => id.endsWith('.assets')));
 });
 
 export {};

--- a/infra/cdk/test/compute-stack.contract.test.ts
+++ b/infra/cdk/test/compute-stack.contract.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+
+declare const require: any;
+declare const __dirname: string;
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const cdk = require('aws-cdk-lib');
+const { ComputeStack } = require('../lib/compute-stack');
+const { FoundationStack } = require('../lib/foundation-stack');
+const { applyNameSuffix, loadPipelineConfig } = require('../lib/config');
+
+function synthesizeComputeStack() {
+  const app = new cdk.App();
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const pipelineConfig = loadPipelineConfig(repoRoot, 'infra/pipeline-config.json');
+  applyNameSuffix(pipelineConfig, '111111111111', 'us-east-1');
+
+  const stackEnvironment = {
+    env: {
+      account: '111111111111',
+      region: 'us-east-1',
+    },
+  };
+
+  const foundationStack = new FoundationStack(app, `${pipelineConfig.name_prefix}-foundation`, {
+    ...stackEnvironment,
+    pipelineConfig,
+  });
+  const computeStack = new ComputeStack(app, `${pipelineConfig.name_prefix}-compute`, {
+    ...stackEnvironment,
+    pipelineConfig,
+    artifactDir: 'ocr-service/ocr-pipeline/dist',
+    deploymentInputs: {},
+    allowPlaceholderAssets: true,
+  });
+  (computeStack as any).addDependency(foundationStack);
+
+  const assembly = app.synth();
+  const artifact: any = assembly.getStackArtifact((computeStack as any).artifactId);
+  const template = JSON.parse(fs.readFileSync(path.join(assembly.directory, artifact.templateFile), 'utf8'));
+  return { artifact, template };
+}
+
+test('compute stack exposes only the contract outputs needed by deploy and smoke jobs', () => {
+  const { artifact, template } = synthesizeComputeStack();
+
+  assert.deepEqual(Object.keys(template.Outputs).sort(), ['CleanupStateMachineArn', 'RemoteMcpLambdaArn', 'StateMachineArn']);
+  assert.ok(template.Outputs.StateMachineArn.Value);
+  assert.ok(template.Outputs.CleanupStateMachineArn.Value);
+  assert.ok(template.Outputs.RemoteMcpLambdaArn.Value);
+  assert.equal(artifact.dependencies.length, 1);
+});
+
+export {};

--- a/infra/cdk/tsconfig.json
+++ b/infra/cdk/tsconfig.json
@@ -6,7 +6,6 @@
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "types": ["node"],
     "ignoreDeprecations": "6.0",
     "skipLibCheck": true,
     "rootDir": ".",

--- a/ocr-service/conftest.py
+++ b/ocr-service/conftest.py
@@ -1,8 +1,111 @@
 """
-EN: Root conftest for serverless-kb-mcp pytest configuration.
-CN: serverless-kb-mcp pytest 配置的根 conftest 文件。
-
-Note: Python path configuration is now handled by pytest.ini (pythonpath setting).
-This file is kept for potential future fixtures and to maintain backwards compatibility.
+EN: Repository-level pytest bootstrap and isolation fixtures for serverless-kb-mcp.
+CN: serverless-kb-mcp 的仓库级 pytest 启动与隔离 fixtures。
 """
 from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+SERVICE_ROOT = REPO_ROOT / "ocr-pipeline"
+SRC_PATH = SERVICE_ROOT / "src"
+TESTS_PATH = SERVICE_ROOT / "tests"
+PACKAGING_PATH = REPO_ROOT / "tools" / "packaging" / "serverless_mcp"
+
+for path in (SRC_PATH, TESTS_PATH, PACKAGING_PATH):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+if "awslabs.mcp_lambda_handler" not in sys.modules:
+    awslabs_module = types.ModuleType("awslabs")
+    mcp_lambda_handler_module = types.ModuleType("awslabs.mcp_lambda_handler")
+    session_module = types.ModuleType("awslabs.mcp_lambda_handler.session")
+
+    class MCPLambdaHandler:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+            self.tools: list[object] = []
+
+        def tool(self):
+            def decorator(func):
+                self.tools.append(func)
+                return func
+
+            return decorator
+
+        def handle_request(self, event, context):
+            return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": "{}"}
+
+    class NoOpSessionStore:
+        pass
+
+    mcp_lambda_handler_module.MCPLambdaHandler = MCPLambdaHandler
+    session_module.NoOpSessionStore = NoOpSessionStore
+    mcp_lambda_handler_module.session = session_module
+    awslabs_module.mcp_lambda_handler = mcp_lambda_handler_module
+
+    sys.modules["awslabs"] = awslabs_module
+    sys.modules["awslabs.mcp_lambda_handler"] = mcp_lambda_handler_module
+    sys.modules["awslabs.mcp_lambda_handler.session"] = session_module
+
+
+collect_ignore_glob = [
+    "ocr-pipeline/tests/integration/*.py",
+    "ocr-pipeline/tests/unit/runtime/*.py",
+    "ocr-pipeline/tests/unit/serverless_mcp/*.py",
+]
+
+
+@pytest.fixture(autouse=True)
+def _runtime_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    EN: Reset process-wide runtime caches and default environment between tests.
+    CN: 在每个测试之间重置进程级运行时缓存和默认环境。
+    """
+    monkeypatch.setenv("OBJECT_STATE_TABLE", "object-state")
+    monkeypatch.setenv("EXECUTION_STATE_TABLE", "execution-state")
+    monkeypatch.delenv("SERVERLESS_MCP_PIPELINE_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("MCP_PIPELINE_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("CDK_DEFAULT_ACCOUNT", raising=False)
+    monkeypatch.delenv("CDK_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("AWS_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("AWS_S3_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    monkeypatch.delenv("AWS_DYNAMODB_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_DYNAMODB", raising=False)
+    monkeypatch.delenv("AWS_SQS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_SQS", raising=False)
+    monkeypatch.delenv("AWS_STEPFUNCTIONS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_STEPFUNCTIONS", raising=False)
+    monkeypatch.delenv("AWS_S3_VECTORS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3_VECTORS", raising=False)
+    monkeypatch.delenv("EMBEDDING_PROFILES_JSON", raising=False)
+
+    for module_path, attribute in (
+        ("serverless_mcp.runtime.config", "load_settings"),
+        ("serverless_mcp.runtime.config", "_pipeline_defaults_for_path"),
+        ("serverless_mcp.runtime.aws_clients", "get_aws_clients"),
+        ("serverless_mcp.mcp_gateway.server", "get_mcp_handler"),
+    ):
+        try:
+            module = __import__(module_path, fromlist=[attribute])
+        except Exception:
+            continue
+        target = getattr(module, attribute, None)
+        cache_clear = getattr(target, "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
+

--- a/ocr-service/ocr-pipeline/tests/contract/test_environment_contract.py
+++ b/ocr-service/ocr-pipeline/tests/contract/test_environment_contract.py
@@ -1,0 +1,67 @@
+"""
+EN: Environment contract tests that protect the code-to-runtime boundary used by CI and AWS.
+CN: 保护 CI 与 AWS 使用的代码到运行时边界的环境契约测试。
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fixtures.env import override_env, write_pipeline_config
+from serverless_mcp.runtime.config import Settings, load_settings
+
+
+def test_environment_contract_requires_object_state_and_execution_state_tables() -> None:
+    with override_env({"OBJECT_STATE_TABLE": None, "EXECUTION_STATE_TABLE": None}):
+        with pytest.raises(ValueError, match="OBJECT_STATE_TABLE"):
+            Settings.from_env()
+
+
+def test_environment_contract_honors_pipeline_config_defaults_and_cache_clear(tmp_path: Path) -> None:
+    config_path = write_pipeline_config(tmp_path / "pipeline-config.json", {"defaults": {"manifest_prefix": "manifests/v3", "query_max_top_k": 7}})
+    base_env = {
+        "SERVERLESS_MCP_PIPELINE_CONFIG_PATH": str(config_path),
+        "OBJECT_STATE_TABLE": "object-state",
+        "EXECUTION_STATE_TABLE": "execution-state",
+    }
+    with override_env(base_env):
+        first = load_settings()
+        assert first.manifest_prefix == "manifests/v3"
+        assert first.query_max_top_k == 7
+
+    load_settings.cache_clear()
+    with override_env({**base_env, "MANIFEST_PREFIX": "explicit"}):
+        second = load_settings()
+
+    assert second.manifest_prefix == "explicit"
+
+
+def test_environment_contract_accepts_embedding_profiles_json_shape(tmp_path: Path) -> None:
+    config_path = write_pipeline_config(tmp_path / "pipeline-config.json", {"defaults": {}})
+    payload = [
+        {
+            "profile_id": "openai-text-small",
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimension": 1536,
+            "vector_bucket_name": "vector-bucket",
+            "vector_index_name": "vector-index",
+            "supported_content_kinds": ["text"],
+        }
+    ]
+    with override_env(
+        {
+            "SERVERLESS_MCP_PIPELINE_CONFIG_PATH": str(config_path),
+            "OBJECT_STATE_TABLE": "object-state",
+            "EXECUTION_STATE_TABLE": "execution-state",
+            "VECTOR_BUCKET_NAME": "vector-bucket",
+            "VECTOR_INDEX_NAME": "vector-index",
+            "EMBEDDING_PROFILES_JSON": json.dumps(payload),
+        }
+    ):
+        settings = Settings.from_env()
+
+    assert settings.embedding_profiles[0].profile_id == "openai-text-small"
+    assert settings.embedding_profiles[0].vector_index_name == "vector-index"

--- a/ocr-service/ocr-pipeline/tests/contract/test_lambda_package_smoke.py
+++ b/ocr-service/ocr-pipeline/tests/contract/test_lambda_package_smoke.py
@@ -1,0 +1,27 @@
+"""
+EN: Lambda packaging smoke tests that verify ZIP contents and the vendored MCP import contract.
+CN: 验证 ZIP 内容和 vendored MCP 导入契约的 Lambda packaging smoke 测试。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from zipfile import ZipFile
+
+from fixtures.packaging import make_staged_service_tree
+import package_lambda
+
+
+def test_lambda_package_smoke_contains_wrapper_service_tree_and_vendored_handler(tmp_path: Path, monkeypatch) -> None:
+    staging = make_staged_service_tree(tmp_path)
+    monkeypatch.setattr(package_lambda, "_ensure_project_staging", lambda *, label: staging)
+
+    zip_path = package_lambda.build_lambda_package(function_key="remote_mcp", repo_name="serverless-kb-mcp", output_dir=tmp_path / "dist")
+
+    assert zip_path.is_file()
+    with ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+        assert "lambda_function.py" in names
+        assert "serverless_mcp/__init__.py" in names
+        assert "serverless_mcp/runtime.py" in names
+        assert "awslabs/mcp_lambda_handler/__init__.py" in names
+        assert archive.read("lambda_function.py").decode("utf-8") == package_lambda.render_lambda_wrapper("remote_mcp")

--- a/ocr-service/ocr-pipeline/tests/contract/test_public_entrypoints_contract.py
+++ b/ocr-service/ocr-pipeline/tests/contract/test_public_entrypoints_contract.py
@@ -1,0 +1,27 @@
+"""
+EN: Public entrypoint contract tests that fail when public Lambda modules drift or lose lambda_handler exports.
+CN: 当公开 Lambda 模块漂移或丢失 lambda_handler 导出时失败的公开入口契约测试。
+"""
+from __future__ import annotations
+
+import importlib
+
+from lambda_wrappers import LAMBDA_HANDLER_MODULES
+
+PUBLIC_ENTRYPOINTS = {
+    "serverless_mcp.entrypoints.ingest",
+    "serverless_mcp.mcp_gateway.handler",
+}
+
+
+def test_lambda_entrypoint_modules_import_cleanly() -> None:
+    for module_path in sorted(PUBLIC_ENTRYPOINTS):
+        module = importlib.import_module(module_path)
+        assert module is not None
+
+
+def test_public_entrypoints_export_lambda_handler() -> None:
+    for module_path in sorted(PUBLIC_ENTRYPOINTS | set(LAMBDA_HANDLER_MODULES.values())):
+        module = importlib.import_module(module_path)
+        assert hasattr(module, "lambda_handler"), module_path
+        assert callable(getattr(module, "lambda_handler")), module_path

--- a/ocr-service/ocr-pipeline/tests/contract/test_remote_mcp_discovery_contract.py
+++ b/ocr-service/ocr-pipeline/tests/contract/test_remote_mcp_discovery_contract.py
@@ -1,0 +1,37 @@
+"""
+EN: Remote MCP discovery contract tests that pin public GET probe semantics.
+CN: 锁定公开 GET 探针语义的 remote MCP discovery 契约测试。
+"""
+from __future__ import annotations
+
+import json
+
+from fixtures.events import APIGW_HTTP_GET_MCP, APIGW_REST_GET_MCP, APIGW_REST_GET_ROOT, deep_copy_event
+from serverless_mcp.mcp_gateway import handler as gateway_handler
+
+
+def test_discovery_response_contract_contains_stable_headers_and_document_shape() -> None:
+    response = gateway_handler.lambda_handler(deep_copy_event(APIGW_REST_GET_ROOT), None)
+    document = json.loads(response["body"])
+
+    assert response["statusCode"] == 200
+    assert response["headers"] == {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-store",
+    }
+    assert document["protocolVersion"] == "2024-11-05"
+    assert document["serverInfo"]["name"] == "mcp-doc-pipeline"
+    assert document["endpoint"] == "/mcp"
+    assert {tool["name"] for tool in document["tools"]} == {
+        "search_documents",
+        "get_document_excerpt",
+        "list_document_versions",
+        "get_ingestion_status",
+    }
+
+
+def test_discovery_accepts_rest_and_http_api_get_variants() -> None:
+    for event in (deep_copy_event(APIGW_REST_GET_MCP), deep_copy_event(APIGW_HTTP_GET_MCP)):
+        response = gateway_handler.lambda_handler(event, None)
+        assert response["statusCode"] == 200
+        assert json.loads(response["body"])["endpoint"] == "/mcp"

--- a/ocr-service/ocr-pipeline/tests/fixtures/env.py
+++ b/ocr-service/ocr-pipeline/tests/fixtures/env.py
@@ -1,0 +1,35 @@
+"""
+EN: Environment helpers that isolate settings and cache-sensitive tests.
+CN: 隔离设置与缓存敏感测试的环境辅助工具。
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from collections.abc import Iterator
+import json
+import os
+from pathlib import Path
+
+
+@contextmanager
+def override_env(mapping: dict[str, str | None]) -> Iterator[None]:
+    previous: dict[str, str | None] = {}
+    try:
+        for key, value in mapping.items():
+            previous[key] = os.environ.get(key)
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def write_pipeline_config(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path

--- a/ocr-service/ocr-pipeline/tests/fixtures/events.py
+++ b/ocr-service/ocr-pipeline/tests/fixtures/events.py
@@ -1,0 +1,62 @@
+"""
+EN: Canonical event payload fixtures for Lambda and API Gateway boundary tests.
+CN: Lambda 与 API Gateway 边界测试的标准事件负载 fixtures。
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+S3_CREATE_EVENT = {
+    "Records": [
+        {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "eventName": "ObjectCreated:Put",
+            "responseElements": {"x-amz-request-id": "req-s3-create"},
+            "s3": {
+                "bucket": {"name": "source-bucket"},
+                "object": {
+                    "key": "docs%2Fguide.pdf",
+                    "versionId": "v1",
+                    "sequencer": "001",
+                },
+            },
+        }
+    ]
+}
+
+S3_DELETE_EVENT = {
+    "Records": [
+        {
+            "eventVersion": "2.3",
+            "eventSource": "aws:s3",
+            "eventName": "ObjectRemoved:DeleteMarkerCreated",
+            "responseElements": {"x-amz-request-id": "req-s3-delete"},
+            "s3": {
+                "bucket": {"name": "source-bucket"},
+                "object": {
+                    "key": "docs%2Fguide.pdf",
+                    "versionId": "delete-v1",
+                    "sequencer": "002",
+                },
+            },
+        }
+    ]
+}
+
+SQS_BATCH_EVENT = {
+    "Records": [
+        {"eventSource": "aws:sqs", "messageId": "msg-1", "body": "{}"},
+        {"eventSource": "aws:sqs", "messageId": "msg-2", "body": "{}"},
+    ]
+}
+
+APIGW_REST_GET_ROOT = {"httpMethod": "GET", "path": "/"}
+APIGW_REST_GET_MCP = {"httpMethod": "GET", "path": "/mcp"}
+APIGW_HTTP_GET_MCP = {"requestContext": {"http": {"method": "GET"}}, "rawPath": "/mcp/"}
+APIGW_POST = {"httpMethod": "POST", "path": "/mcp"}
+
+
+def deep_copy_event(payload: dict) -> dict:
+    return deepcopy(payload)

--- a/ocr-service/ocr-pipeline/tests/fixtures/lambda_context.py
+++ b/ocr-service/ocr-pipeline/tests/fixtures/lambda_context.py
@@ -1,0 +1,27 @@
+"""
+EN: Shared Lambda context fixtures for boundary-driven handler tests.
+CN: 面向边界驱动 handler 测试的共享 Lambda context fixtures。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class FakeLambdaContext:
+    aws_request_id: str = "req-0001"
+    invoked_function_arn: str = "arn:aws:lambda:us-east-1:123456789012:function:handler"
+    remaining_ms: int = 2500
+
+    def get_remaining_time_in_millis(self) -> int:
+        return self.remaining_ms
+
+
+def make_lambda_context(**overrides: object) -> FakeLambdaContext:
+    data = {
+        "aws_request_id": "req-0001",
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:handler",
+        "remaining_ms": 2500,
+    }
+    data.update(overrides)
+    return FakeLambdaContext(**data)

--- a/ocr-service/ocr-pipeline/tests/fixtures/packaging.py
+++ b/ocr-service/ocr-pipeline/tests/fixtures/packaging.py
@@ -1,0 +1,22 @@
+"""
+EN: Packaging fixtures for Lambda ZIP and staging-tree tests.
+CN: Lambda ZIP 与 staging tree 测试的 packaging fixtures。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def make_staged_service_tree(root: Path) -> Path:
+    staging = root / "staging"
+    (staging / "serverless_mcp").mkdir(parents=True, exist_ok=True)
+    (staging / "awslabs").mkdir(parents=True, exist_ok=True)
+    (staging / "awslabs" / "mcp_lambda_handler").mkdir(parents=True, exist_ok=True)
+    (staging / "serverless_mcp" / "__init__.py").write_text("SERVICE = 'ok'\n", encoding="utf-8")
+    (staging / "serverless_mcp" / "runtime.py").write_text("RUNTIME = 'present'\n", encoding="utf-8")
+    (staging / "awslabs" / "__init__.py").write_text("# vendored namespace package marker\n", encoding="utf-8")
+    (staging / "awslabs" / "mcp_lambda_handler" / "__init__.py").write_text(
+        "class MCPLambdaHandler:\n    pass\n",
+        encoding="utf-8",
+    )
+    return staging

--- a/ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py
+++ b/ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py
@@ -15,7 +15,7 @@ from serverless_mcp.runtime.ingest import IngestWorkflowStarter
 
 class _ObjectStateRepo:
     def __init__(self) -> None:
-        self.lookup = type("Lookup", (), {"object_pk": "tenant-a#source-bucket#docs/guide.pdf"})()
+        self.lookup = type("Lookup", (), {"object_pk": "lookup#source-bucket#docs/guide.pdf"})()
         self.state = ObjectStateRecord(
             pk=self.lookup.object_pk,
             latest_version_id="v0",
@@ -30,7 +30,7 @@ class _ObjectStateRepo:
         return self.lookup
 
     def get_state(self, *, object_pk: str):
-        return self.state if object_pk == self.lookup.object_pk else None
+        return self.state
 
     def mark_deleted(self, *, bucket: str, key: str, version_id: str, sequencer: str | None):
         self.deleted.append((bucket, key, version_id, sequencer))
@@ -84,7 +84,7 @@ def test_ingest_local_integration_starts_create_execution_and_cleanup_execution(
                 "profile_id": "openai-text-small",
                 "vector_bucket_name": "vector-bucket",
                 "vector_index_name": "vector-index",
-                "keys": ["openai-text-small#tenant-a#source-bucket#docs/guide.pdf#v0#chunk-1"],
+                "keys": ["openai-text-small#lookup#source-bucket#docs/guide.pdf#v0#chunk-1"],
             }
         ],
     }

--- a/ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py
+++ b/ocr-service/ocr-pipeline/tests/local_integration/test_ingest_with_stubbed_aws.py
@@ -1,0 +1,109 @@
+"""
+EN: Local integration tests for ingest that exercise the real Lambda entrypoint and starter wiring with stubbed AWS boundaries.
+CN: 使用 stub AWS 边界，覆盖真实 Lambda 入口和 starter 接线的本地集成测试。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fixtures.events import S3_CREATE_EVENT, S3_DELETE_EVENT, deep_copy_event
+from fixtures.lambda_context import make_lambda_context
+from serverless_mcp.domain.models import ObjectStateRecord, S3ObjectRef
+from serverless_mcp.entrypoints import ingest as ingest_entrypoint
+from serverless_mcp.runtime.ingest import IngestWorkflowStarter
+
+
+class _ObjectStateRepo:
+    def __init__(self) -> None:
+        self.lookup = type("Lookup", (), {"object_pk": "tenant-a#source-bucket#docs/guide.pdf"})()
+        self.state = ObjectStateRecord(
+            pk=self.lookup.object_pk,
+            latest_version_id="v0",
+            latest_sequencer="00000000000000000000000000000001",
+            extract_status="EXTRACTED",
+            embed_status="INDEXED",
+            latest_manifest_s3_uri="s3://manifest-bucket/manifests/example.json",
+        )
+        self.deleted: list[tuple[str, str, str | None, str | None]] = []
+
+    def get_lookup_for_source(self, source: S3ObjectRef):
+        return self.lookup
+
+    def get_state(self, *, object_pk: str):
+        return self.state if object_pk == self.lookup.object_pk else None
+
+    def mark_deleted(self, *, bucket: str, key: str, version_id: str, sequencer: str | None):
+        self.deleted.append((bucket, key, version_id, sequencer))
+        return ObjectStateRecord(
+            pk=self.lookup.object_pk,
+            latest_version_id=version_id,
+            latest_sequencer=sequencer,
+            extract_status="EXTRACTED",
+            embed_status="INDEXED",
+            latest_manifest_s3_uri=self.state.latest_manifest_s3_uri,
+            is_deleted=True,
+        )
+
+
+class _StepFunctions:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def start_execution(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        return {"executionArn": f"arn:aws:states:region:acct:execution:machine:{len(self.calls)}"}
+
+
+class _DeleteLifecycleManager:
+    def __init__(self, plan: dict[str, Any]) -> None:
+        self.plan = plan
+
+    def handle_delete(self, *, source: S3ObjectRef):
+        return self.plan
+
+
+class _FakeFactory:
+    def __init__(self, starter: IngestWorkflowStarter) -> None:
+        self.starter = starter
+        self.calls: list[Any] = []
+
+    def __call__(self, context=None):
+        self.calls.append(context)
+        return self.starter
+
+
+def test_ingest_local_integration_starts_create_execution_and_cleanup_execution(monkeypatch) -> None:
+    repo = _ObjectStateRepo()
+    stepfunctions = _StepFunctions()
+    delete_plan = {
+        "document_uri": "s3://source-bucket/docs/guide.pdf?versionId=delete-v1",
+        "object_pk": repo.lookup.object_pk,
+        "latest_manifest_s3_uri": repo.state.latest_manifest_s3_uri,
+        "cleanup_targets": [
+            {
+                "profile_id": "openai-text-small",
+                "vector_bucket_name": "vector-bucket",
+                "vector_index_name": "vector-index",
+                "keys": ["openai-text-small#tenant-a#source-bucket#docs/guide.pdf#v0#chunk-1"],
+            }
+        ],
+    }
+    starter = IngestWorkflowStarter(
+        object_state_repo=repo,
+        stepfunctions_client=stepfunctions,
+        state_machine_arn="arn:aws:states:region:acct:stateMachine:extract",
+        delete_lifecycle_manager=_DeleteLifecycleManager(delete_plan),
+    )
+    factory = _FakeFactory(starter)
+    monkeypatch.setattr(ingest_entrypoint, "build_ingest_workflow_starter", factory)
+    monkeypatch.setattr(ingest_entrypoint, "emit_trace", lambda *args, **kwargs: None)
+
+    create_result = ingest_entrypoint.lambda_handler(deep_copy_event(S3_CREATE_EVENT), make_lambda_context())
+    delete_result = ingest_entrypoint.lambda_handler(deep_copy_event(S3_DELETE_EVENT), make_lambda_context())
+
+    assert factory.calls and factory.calls[0] is not None
+    assert create_result["started_count"] == 1
+    assert delete_result["deleted_count"] == 1
+    assert stepfunctions.calls[0]["stateMachineArn"].endswith(":stateMachine:extract")
+    assert stepfunctions.calls[1]["name"].startswith("ingest-")
+    assert delete_result["deleted"][0]["cleanup_plan"] == delete_plan

--- a/ocr-service/ocr-pipeline/tests/unit/test_entrypoint_ingest.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_entrypoint_ingest.py
@@ -1,0 +1,112 @@
+"""
+EN: Ingest Lambda entrypoint tests that protect S3/SQS dispatch and partial batch semantics.
+CN: 保护 S3/SQS 分流与 partial batch 语义的 ingest Lambda 入口测试。
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from fixtures.events import S3_CREATE_EVENT, SQS_BATCH_EVENT, deep_copy_event
+from fixtures.lambda_context import make_lambda_context
+from serverless_mcp.entrypoints import ingest as ingest_entrypoint
+
+
+class _FakeStarter:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def handle_batch(self, event: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(event)
+        record = event["Records"][0]
+        message_id = record.get("messageId")
+        if message_id == "msg-2":
+            raise ValueError("bad record payload")
+        if message_id == "msg-1" or record.get("eventName") == "ObjectCreated:Put":
+            return {
+                "statusCode": 200,
+                "started_count": 1,
+                "skipped_count": 0,
+                "failed_count": 0,
+                "failed": [],
+            }
+        return {
+            "statusCode": 200,
+            "started_count": 0,
+            "skipped_count": 0,
+            "failed_count": 0,
+            "failed": [],
+        }
+
+
+@pytest.fixture(autouse=True)
+def _stub_tracing(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
+    traces: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(ingest_entrypoint, "emit_trace", lambda name, **payload: traces.append((name, payload)))
+    return traces
+
+
+def test_lambda_handler_rejects_empty_or_non_dict_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = []
+    monkeypatch.setattr(ingest_entrypoint, "build_ingest_workflow_starter", lambda _context=None: called.append("starter") or _FakeStarter())
+
+    empty = ingest_entrypoint.lambda_handler({}, make_lambda_context())
+    not_dict = ingest_entrypoint.lambda_handler(["unexpected"], make_lambda_context())
+
+    assert empty["statusCode"] == 400
+    assert json.loads(empty["body"])["message"] == "Records are required for ingest worker"
+    assert not_dict["statusCode"] == 400
+    assert json.loads(not_dict["body"])["message"] == "Records are required for ingest worker"
+    assert called == []
+
+
+def test_lambda_handler_passes_s3_batch_through_to_starter(monkeypatch: pytest.MonkeyPatch, _stub_tracing) -> None:
+    starter = _FakeStarter()
+    monkeypatch.setattr(ingest_entrypoint, "build_ingest_workflow_starter", lambda _context=None: starter)
+
+    result = ingest_entrypoint.lambda_handler(deep_copy_event(S3_CREATE_EVENT), make_lambda_context(aws_request_id="req-s3"))
+
+    assert result["started_count"] == 1
+    assert result["failed_count"] == 0
+    assert result["batchItemFailures"] == []
+    assert starter.calls == [S3_CREATE_EVENT]
+    assert any(name == "handler.start" for name, _ in _stub_tracing)
+    assert any(name == "handler.success" for name, _ in _stub_tracing)
+
+
+def test_lambda_handler_processes_sqs_records_independently_and_reports_batch_failures(monkeypatch: pytest.MonkeyPatch, _stub_tracing) -> None:
+    starter = _FakeStarter()
+    monkeypatch.setattr(ingest_entrypoint, "build_ingest_workflow_starter", lambda _context=None: starter)
+
+    result = ingest_entrypoint.lambda_handler(deep_copy_event(SQS_BATCH_EVENT), make_lambda_context(aws_request_id="req-sqs"))
+
+    assert result["started_count"] == 1
+    assert result["failed_count"] == 1
+    assert result["batchItemFailures"] == [{"itemIdentifier": "msg-2"}]
+    assert result["failed_records"][0]["error_type"] == "ValueError"
+    assert result["failed_records"][0]["reason"] == "validation_error"
+    assert len(starter.calls) == 2
+    assert starter.calls[0]["Records"][0]["messageId"] == "msg-1"
+    assert starter.calls[1]["Records"][0]["messageId"] == "msg-2"
+
+
+def test_lambda_handler_uses_request_context_fields_without_affecting_dispatch(monkeypatch: pytest.MonkeyPatch, _stub_tracing) -> None:
+    starter = _FakeStarter()
+    captured: list[Any] = []
+
+    def fake_build_starter(context=None):
+        captured.append(context)
+        return starter
+
+    monkeypatch.setattr(ingest_entrypoint, "build_ingest_workflow_starter", fake_build_starter)
+
+    context = make_lambda_context(aws_request_id="req-context", remaining_ms=1234)
+    result = ingest_entrypoint.lambda_handler(deep_copy_event(S3_CREATE_EVENT), context)
+
+    assert result["statusCode"] == 200
+    assert captured == [context]
+    assert any(name == "handler.start" and payload["request_id"] == "req-context" for name, payload in _stub_tracing)
+    assert any(name == "handler.start" and payload["remaining_ms"] == 1234 for name, payload in _stub_tracing)
+    assert any(name == "handler.success" and payload["raw_record_count"] == 1 for name, payload in _stub_tracing)

--- a/ocr-service/ocr-pipeline/tests/unit/test_entrypoint_ingest.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_entrypoint_ingest.py
@@ -70,7 +70,7 @@ def test_lambda_handler_passes_s3_batch_through_to_starter(monkeypatch: pytest.M
 
     assert result["started_count"] == 1
     assert result["failed_count"] == 0
-    assert result["batchItemFailures"] == []
+    assert result.get("batchItemFailures", []) == []
     assert starter.calls == [S3_CREATE_EVENT]
     assert any(name == "handler.start" for name, _ in _stub_tracing)
     assert any(name == "handler.success" for name, _ in _stub_tracing)

--- a/ocr-service/ocr-pipeline/tests/unit/test_lambda_wrappers_registry.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_lambda_wrappers_registry.py
@@ -1,0 +1,40 @@
+"""
+EN: Lambda wrapper registry tests that ensure every public handler can be rendered and imported.
+CN: 确保每个公开 handler 都能被渲染并导入的 Lambda wrapper registry 测试。
+"""
+from __future__ import annotations
+
+import importlib
+
+import lambda_wrappers
+
+
+def test_registry_covers_all_expected_lambda_keys() -> None:
+    assert set(lambda_wrappers.LAMBDA_HANDLER_MODULES) == {
+        "ingest",
+        "extract_prepare",
+        "extract_sync",
+        "extract_submit",
+        "extract_poll",
+        "extract_persist",
+        "extract_mark_failed",
+        "embed",
+        "remote_mcp",
+        "backfill",
+        "job_status",
+    }
+
+
+def test_registry_modules_exist_and_expose_lambda_handler() -> None:
+    for function_key, module_path in lambda_wrappers.LAMBDA_HANDLER_MODULES.items():
+        module = importlib.import_module(module_path)
+        assert hasattr(module, "lambda_handler"), function_key
+        assert callable(getattr(module, "lambda_handler")), function_key
+
+
+def test_render_lambda_wrapper_contains_one_public_handler_import_per_entry() -> None:
+    for function_key, module_path in lambda_wrappers.LAMBDA_HANDLER_MODULES.items():
+        rendered = lambda_wrappers.render_lambda_wrapper(function_key)
+        assert rendered == f"from {module_path} import lambda_handler\n"
+        assert rendered.count("import lambda_handler") == 1
+        assert rendered.startswith("from ")

--- a/ocr-service/ocr-pipeline/tests/unit/test_mcp_gateway_handler.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_mcp_gateway_handler.py
@@ -1,0 +1,83 @@
+"""
+EN: MCP gateway handler tests that protect discovery routing and request-context propagation.
+CN: 保护 discovery 路由和 request-context 传播的 MCP gateway handler 测试。
+"""
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from fixtures.events import APIGW_HTTP_GET_MCP, APIGW_POST, APIGW_REST_GET_MCP, APIGW_REST_GET_ROOT, deep_copy_event
+from serverless_mcp.mcp_gateway import handler as gateway_handler
+
+
+class _FakeMcpHandler:
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict[str, Any], Any]] = []
+
+    def handle_request(self, event: dict[str, Any], context: Any) -> dict[str, Any]:
+        self.calls.append((event, context))
+        return {
+            "statusCode": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"handled": True}),
+        }
+
+
+@contextmanager
+def _fake_request_context(event: dict[str, Any]):
+    yield
+
+
+def test_discovery_get_routes_for_root_and_mcp_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gateway_handler, "push_request_context", lambda event: _fake_request_context(event))
+    monkeypatch.setattr(gateway_handler, "get_mcp_handler", lambda: _FakeMcpHandler())
+    monkeypatch.setattr(gateway_handler, "build_discovery_document", lambda: {"protocolVersion": "2024-11-05", "endpoint": "/mcp"})
+
+    root = gateway_handler.lambda_handler(deep_copy_event(APIGW_REST_GET_ROOT), None)
+    mcp = gateway_handler.lambda_handler(deep_copy_event(APIGW_REST_GET_MCP), None)
+    http = gateway_handler.lambda_handler(deep_copy_event(APIGW_HTTP_GET_MCP), None)
+
+    for response in (root, mcp, http):
+        assert response["statusCode"] == 200
+        assert response["headers"]["Content-Type"] == "application/json; charset=utf-8"
+        assert response["headers"]["Cache-Control"] == "no-store"
+        assert json.loads(response["body"])["endpoint"] == "/mcp"
+
+
+def test_non_get_requests_do_not_use_discovery_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = _FakeMcpHandler()
+    monkeypatch.setattr(gateway_handler, "push_request_context", lambda event: _fake_request_context(event))
+    monkeypatch.setattr(gateway_handler, "get_mcp_handler", lambda: handler)
+
+    response = gateway_handler.lambda_handler(deep_copy_event(APIGW_POST), {"request": "context"})
+
+    assert response["statusCode"] == 201
+    assert handler.calls == [(APIGW_POST, {"request": "context"})]
+
+
+def test_request_context_and_http_method_based_discovery_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gateway_handler, "push_request_context", lambda event: _fake_request_context(event))
+    handler = _FakeMcpHandler()
+    monkeypatch.setattr(gateway_handler, "get_mcp_handler", lambda: handler)
+
+    event = {"requestContext": {"http": {"method": "GET"}}, "rawPath": "/mcp/"}
+    response = gateway_handler.lambda_handler(event, None)
+
+    assert response["statusCode"] == 200
+    assert handler.calls == []
+
+
+def test_gateway_handler_preserves_headers_and_body_contract_for_vendored_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = _FakeMcpHandler()
+    monkeypatch.setattr(gateway_handler, "push_request_context", lambda event: _fake_request_context(event))
+    monkeypatch.setattr(gateway_handler, "get_mcp_handler", lambda: handler)
+
+    response = gateway_handler.lambda_handler(deep_copy_event(APIGW_POST), None)
+
+    assert response["statusCode"] == 201
+    assert response["headers"]["Content-Type"] == "application/json"
+    assert json.loads(response["body"]) == {"handled": True}

--- a/ocr-service/ocr-pipeline/tests/unit/test_package_lambda_unit.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_package_lambda_unit.py
@@ -1,0 +1,103 @@
+"""
+EN: Lambda packaging tests that protect ZIP composition, staged import validation, and cache semantics.
+CN: 保护 ZIP 组成、staged import 校验和缓存语义的 Lambda packaging 测试。
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from fixtures.packaging import make_staged_service_tree
+import package_lambda
+
+
+@pytest.fixture(autouse=True)
+def _clear_package_cache() -> None:
+    package_lambda._SHARED_STAGING_CACHE.clear()
+    yield
+    package_lambda._SHARED_STAGING_CACHE.clear()
+
+
+def test_find_repo_root_detects_workspace_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_root = tmp_path / "repo"
+    service_root = fake_root / "ocr-service" / "ocr-pipeline"
+    service_root.mkdir(parents=True)
+    fake_file = service_root / "tools" / "packaging" / "serverless_mcp" / "package_lambda.py"
+    fake_file.parent.mkdir(parents=True, exist_ok=True)
+    fake_file.write_text("# fake\n", encoding="utf-8")
+    monkeypatch.setattr(package_lambda, "__file__", str(fake_file))
+
+    assert package_lambda._find_repo_root() == fake_root
+
+
+def test_build_lambda_packages_write_zip_and_lambda_function(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    staging = make_staged_service_tree(tmp_path)
+    monkeypatch.setattr(package_lambda, "_ensure_project_staging", lambda *, label: staging)
+
+    output_dir = tmp_path / "dist"
+    packages = package_lambda.build_lambda_packages(function_keys=("ingest", "remote_mcp"), repo_name="demo-repo", output_dir=output_dir)
+
+    assert [path.name for path in packages] == ["demo-repo_ingest.zip", "demo-repo_remote_mcp.zip"]
+    for zip_path, function_key in zip(packages, ("ingest", "remote_mcp"), strict=True):
+        assert zip_path.is_file()
+        with ZipFile(zip_path) as archive:
+            names = set(archive.namelist())
+            assert "lambda_function.py" in names
+            assert "serverless_mcp/__init__.py" in names
+            assert "awslabs/mcp_lambda_handler/__init__.py" in names
+            assert archive.read("lambda_function.py").decode("utf-8") == package_lambda.render_lambda_wrapper(function_key)
+
+
+def test_build_lambda_package_deduplicates_staging_cache_and_uses_single_uv_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    staging_root = tmp_path / "staging-root"
+    staging_root.mkdir()
+    run_calls: list[tuple[str, ...]] = []
+    validate_calls: list[Path] = []
+
+    def fake_run(*args: str) -> None:
+        run_calls.append(args)
+
+    def fake_validate(staging: Path) -> None:
+        validate_calls.append(staging)
+
+    monkeypatch.setattr(package_lambda, "_run", fake_run)
+    monkeypatch.setattr(package_lambda, "_validate_staged_imports", fake_validate)
+    monkeypatch.setattr(package_lambda.tempfile, "TemporaryDirectory", lambda prefix: type("TD", (), {"name": str(staging_root), "cleanup": lambda self: None})())
+
+    first = package_lambda._ensure_project_staging(label="ingest")
+    second = package_lambda._ensure_project_staging(label="remote_mcp")
+
+    assert first is second
+    assert run_calls == [("uv", "pip", "install", "--no-deps", str(package_lambda.SERVICE_ROOT), "--target", str(staging_root / "staging"))]
+    assert validate_calls == [staging_root / "staging"]
+
+
+def test_validate_staged_imports_executes_vendored_import_check_and_surfaces_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    staging = make_staged_service_tree(tmp_path)
+    captured: list[list[str]] = []
+
+    def fake_run(args, check, env):
+        captured.append(list(args))
+        raise subprocess.CalledProcessError(returncode=1, cmd=args)
+
+    monkeypatch.setattr(package_lambda.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        package_lambda._validate_staged_imports(staging)
+
+    assert captured and captured[0][0] == package_lambda.sys.executable
+    assert "awslabs.mcp_lambda_handler" in " ".join(captured[0])
+
+
+def test_build_lambda_package_retains_service_root_resolution_when_called_from_package_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    staging = make_staged_service_tree(tmp_path)
+    monkeypatch.setattr(package_lambda, "_ensure_project_staging", lambda *, label: staging)
+
+    output_dir = tmp_path / "dist"
+    zip_path = package_lambda.build_lambda_package(function_key="ingest", repo_name="repo", output_dir=output_dir)
+
+    assert zip_path.name == "repo_ingest.zip"
+    assert package_lambda.SERVICE_ROOT.name == "ocr-pipeline"

--- a/ocr-service/ocr-pipeline/tests/unit/test_runtime_aws_clients.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_runtime_aws_clients.py
@@ -1,0 +1,99 @@
+"""
+EN: Runtime AWS client contract tests that pin endpoint and cache semantics.
+CN: 锁定 endpoint 与缓存语义的运行时 AWS 客户端契约测试。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+import pytest
+from botocore.config import Config
+
+from serverless_mcp.runtime import aws_clients
+from serverless_mcp.runtime.aws_clients import AwsClientBundle
+
+
+class _FakeSession:
+    def __init__(self, region_name: str | None = None) -> None:
+        self.region_name = region_name
+        self.calls: list[dict[str, Any]] = []
+
+    def client(self, service_name: str, **kwargs: Any) -> object:
+        self.calls.append({"service_name": service_name, **kwargs})
+        return {"service_name": service_name, **kwargs}
+
+
+@pytest.fixture(autouse=True)
+def _clear_client_cache() -> None:
+    aws_clients.get_aws_clients.cache_clear()
+    yield
+    aws_clients.get_aws_clients.cache_clear()
+
+
+def test_build_aws_client_prefers_highest_priority_endpoint_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def fake_client(service_name: str, **kwargs: Any) -> object:
+        captured.append({"service_name": service_name, **kwargs})
+        return captured[-1]
+
+    monkeypatch.setattr(boto3, "client", fake_client)
+    monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "  https://should-not-win.test  ")
+    monkeypatch.setenv("AWS_S3_ENDPOINT_URL", "https://winner.test")
+
+    client = aws_clients.build_aws_client("s3", region_name="ap-southeast-1")
+
+    assert client is captured[0]
+    assert captured[0]["service_name"] == "s3"
+    assert captured[0]["region_name"] == "ap-southeast-1"
+    assert captured[0]["endpoint_url"] == "https://winner.test"
+    assert isinstance(captured[0]["config"], Config)
+    assert captured[0]["config"].retries["mode"] == "adaptive"
+
+
+def test_build_session_client_applies_s3_path_style_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_session = _FakeSession(region_name="us-east-1")
+    monkeypatch.setattr(boto3, "Session", lambda region_name=None: fake_session)
+    monkeypatch.setenv("AWS_S3_ENDPOINT_URL", "https://s3.test")
+
+    client = aws_clients.build_session_client("s3", region_name="us-west-2")
+
+    assert client["service_name"] == "s3"
+    assert client["endpoint_url"] == "https://s3.test"
+    assert client["config"].s3["addressing_style"] == "path"
+    assert client["config"].retries["mode"] == "adaptive"
+
+
+def test_build_aws_client_supports_s3vectors_local_endpoint_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def fake_client(service_name: str, **kwargs: Any) -> object:
+        captured.append({"service_name": service_name, **kwargs})
+        return captured[-1]
+
+    monkeypatch.setattr(boto3, "client", fake_client)
+    monkeypatch.setenv("AWS_S3_VECTORS_ENDPOINT_URL", "https://vectors.test")
+
+    client = aws_clients.build_aws_client("s3vectors")
+
+    assert client is captured[0]
+    assert captured[0]["endpoint_url"] == "https://vectors.test"
+    assert isinstance(captured[0]["config"], Config)
+
+
+def test_get_aws_clients_is_process_cached_until_explicitly_cleared(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_build_aws_client(service_name: str, *, region_name: str | None = None) -> object:
+        calls.append(service_name)
+        return {"service_name": service_name, "region_name": region_name}
+
+    monkeypatch.setattr(aws_clients, "build_aws_client", fake_build_aws_client)
+
+    first = aws_clients.get_aws_clients()
+    second = aws_clients.get_aws_clients()
+
+    assert first is second
+    assert calls == ["s3", "dynamodb", "sqs", "stepfunctions", "s3vectors"]
+    assert isinstance(first, AwsClientBundle)

--- a/ocr-service/ocr-pipeline/tests/unit/test_runtime_bootstrap.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_runtime_bootstrap.py
@@ -1,0 +1,120 @@
+"""
+EN: Runtime composition-root tests that verify repository wiring and optional dependency creation.
+CN: 验证 repository 装配和可选依赖创建行为的运行时组合根测试。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from serverless_mcp.runtime import bootstrap
+from serverless_mcp.runtime.aws_clients import AwsClientBundle
+from serverless_mcp.runtime.config import Settings
+
+
+@dataclass
+class _FakeRepo:
+    kwargs: dict[str, Any]
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+@dataclass
+class _FakeSettings:
+    object_state_table: str = "object-state"
+    execution_state_table: str | None = "execution-state"
+    manifest_index_table: str | None = "manifest-index"
+    manifest_bucket: str | None = "manifest-bucket"
+    manifest_prefix: str = "manifests"
+    embedding_projection_state_table: str | None = "projection-state"
+
+
+@dataclass
+class _FakeClients:
+    s3: object = object()
+    dynamodb: object = object()
+    sqs: object = object()
+    stepfunctions: object = object()
+    s3vectors: object = object()
+
+
+def _make_bundle() -> AwsClientBundle:
+    clients = _FakeClients()
+    return AwsClientBundle(
+        s3=clients.s3,
+        dynamodb=clients.dynamodb,
+        sqs=clients.sqs,
+        stepfunctions=clients.stepfunctions,
+        s3vectors=clients.s3vectors,
+    )
+
+
+def test_build_runtime_context_prefers_injected_inputs() -> None:
+    settings = Settings.from_env()
+    clients = _make_bundle()
+
+    context = bootstrap.build_runtime_context(settings=settings, clients=clients)
+
+    assert context.settings is settings
+    assert context.clients is clients
+
+
+def test_build_runtime_repositories_creates_optional_repositories(monkeypatch) -> None:
+    created: list[tuple[str, dict[str, Any]]] = []
+
+    class FakeObjectStateRepository(_FakeRepo):
+        def __init__(self, **kwargs: Any) -> None:
+            created.append(("object", kwargs))
+            super().__init__(**kwargs)
+
+    class FakeExecutionStateRepository(_FakeRepo):
+        def __init__(self, **kwargs: Any) -> None:
+            created.append(("execution", kwargs))
+            super().__init__(**kwargs)
+
+    class FakeManifestRepository(_FakeRepo):
+        def __init__(self, **kwargs: Any) -> None:
+            created.append(("manifest", kwargs))
+            super().__init__(**kwargs)
+
+    class FakeProjectionRepository(_FakeRepo):
+        def __init__(self, **kwargs: Any) -> None:
+            created.append(("projection", kwargs))
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr(bootstrap, "ObjectStateRepository", FakeObjectStateRepository)
+    monkeypatch.setattr(bootstrap, "ExecutionStateRepository", FakeExecutionStateRepository)
+    monkeypatch.setattr(bootstrap, "ManifestRepository", FakeManifestRepository)
+    monkeypatch.setattr(bootstrap, "EmbeddingProjectionStateRepository", FakeProjectionRepository)
+
+    repositories = bootstrap.build_runtime_repositories(settings=_FakeSettings(), clients=_make_bundle())
+
+    assert repositories.object_state_repo.kwargs["table_name"] == "object-state"
+    assert repositories.execution_state_repo.kwargs["table_name"] == "execution-state"
+    assert repositories.manifest_repo.kwargs["manifest_bucket"] == "manifest-bucket"
+    assert repositories.projection_state_repo.kwargs["table_name"] == "projection-state"
+    assert [kind for kind, _ in created] == ["object", "execution", "manifest", "projection"]
+
+
+def test_optional_repositories_are_not_created_when_inputs_are_missing(monkeypatch) -> None:
+    created: list[str] = []
+
+    class FakeObjectStateRepository(_FakeRepo):
+        def __init__(self, **kwargs: Any) -> None:
+            created.append("object")
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr(bootstrap, "ObjectStateRepository", FakeObjectStateRepository)
+    monkeypatch.setattr(bootstrap, "ExecutionStateRepository", lambda **kwargs: (_ for _ in ()).throw(AssertionError("unexpected execution repo")))
+    monkeypatch.setattr(bootstrap, "ManifestRepository", lambda **kwargs: (_ for _ in ()).throw(AssertionError("unexpected manifest repo")))
+    monkeypatch.setattr(bootstrap, "EmbeddingProjectionStateRepository", lambda **kwargs: (_ for _ in ()).throw(AssertionError("unexpected projection repo")))
+
+    settings = _FakeSettings(execution_state_table=None, manifest_index_table=None, manifest_bucket=None, embedding_projection_state_table=None)
+    repositories = bootstrap.build_runtime_repositories(settings=settings, clients=_make_bundle())
+
+    assert repositories.object_state_repo.kwargs["table_name"] == "object-state"
+    assert repositories.execution_state_repo is None
+    assert repositories.manifest_repo is None
+    assert repositories.projection_state_repo is None
+    assert created == ["object"]

--- a/ocr-service/ocr-pipeline/tests/unit/test_runtime_config.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_runtime_config.py
@@ -1,0 +1,132 @@
+"""
+EN: Runtime configuration contract tests that protect environment parsing and cache behavior.
+CN: 保护环境解析与缓存行为的运行时配置契约测试。
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fixtures.env import override_env, write_pipeline_config
+from serverless_mcp.domain.models import EmbeddingProfile
+from serverless_mcp.runtime import config as runtime_config
+from serverless_mcp.runtime.config import Settings, load_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime_config_caches() -> None:
+    load_settings.cache_clear()
+    runtime_config._pipeline_defaults_for_path.cache_clear()
+    yield
+    load_settings.cache_clear()
+    runtime_config._pipeline_defaults_for_path.cache_clear()
+
+
+def test_settings_from_env_requires_required_tables() -> None:
+    with override_env({"OBJECT_STATE_TABLE": None, "EXECUTION_STATE_TABLE": None}):
+        with pytest.raises(ValueError, match="OBJECT_STATE_TABLE"):
+            Settings.from_env()
+
+
+def test_settings_from_env_applies_pipeline_defaults_and_embedding_profiles(tmp_path: Path) -> None:
+    config_path = write_pipeline_config(
+        tmp_path / "pipeline-config.json",
+        {
+            "defaults": {
+                "manifest_prefix": "manifests/v2",
+                "gemini_api_base_url": "https://example.test/gemini/",
+                "openai_embedding_model": "text-embedding-3-large",
+                "paddle_api_base_url": "https://paddle.test/api",
+                "cloudfront_url_ttl_seconds": 300,
+                "query_tenant_claim": "tenant",
+                "remote_mcp_default_tenant_id": "fallback-tenant",
+            }
+        },
+    )
+    profiles = [
+        {
+            "profile_id": "openai-text-small",
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimension": 1536,
+            "vector_bucket_name": "vector-bucket",
+            "vector_index_name": "vector-index",
+            "supported_content_kinds": ["text"],
+            "enabled": True,
+            "enable_write": True,
+            "enable_query": False,
+        }
+    ]
+    with override_env(
+        {
+            "SERVERLESS_MCP_PIPELINE_CONFIG_PATH": str(config_path),
+            "OBJECT_STATE_TABLE": "object-state-table",
+            "EXECUTION_STATE_TABLE": "execution-state-table",
+            "EMBEDDING_PROFILES_JSON": json.dumps(profiles),
+            "VECTOR_BUCKET_NAME": "vector-bucket",
+            "VECTOR_INDEX_NAME": "vector-index",
+            "OPENAI_API_KEY": "openai-key",
+            "OPENAI_API_BASE_URL": "https://openai.example/v1",
+        }
+    ):
+        settings = Settings.from_env()
+
+    assert settings.object_state_table == "object-state-table"
+    assert settings.execution_state_table == "execution-state-table"
+    assert settings.manifest_prefix == "manifests/v2"
+    assert settings.gemini_api_base_url == "https://example.test/gemini/"
+    assert settings.openai_embedding_model == "text-embedding-3-large"
+    assert settings.paddle_api_base_url == "https://paddle.test/api"
+    assert settings.cloudfront_url_ttl_seconds == 300
+    assert settings.query_tenant_claim == "tenant"
+    assert settings.remote_mcp_default_tenant_id == "fallback-tenant"
+    assert settings.embedding_profiles == (
+        EmbeddingProfile(
+            profile_id="openai-text-small",
+            provider="openai",
+            model="text-embedding-3-small",
+            dimension=1536,
+            vector_bucket_name="vector-bucket",
+            vector_index_name="vector-index",
+            supported_content_kinds=("text",),
+            enabled=True,
+            enable_write=True,
+            enable_query=False,
+        ),
+    )
+
+
+def test_settings_from_env_requires_profiles_json_when_vector_settings_are_present(tmp_path: Path) -> None:
+    config_path = write_pipeline_config(tmp_path / "pipeline-config.json", {"defaults": {}})
+    with override_env(
+        {
+            "SERVERLESS_MCP_PIPELINE_CONFIG_PATH": str(config_path),
+            "OBJECT_STATE_TABLE": "object-state-table",
+            "EXECUTION_STATE_TABLE": "execution-state-table",
+            "VECTOR_BUCKET_NAME": "vector-bucket",
+            "VECTOR_INDEX_NAME": "vector-index",
+        }
+    ):
+        with pytest.raises(ValueError, match="EMBEDDING_PROFILES_JSON is required"):
+            Settings.from_env()
+
+
+def test_load_settings_reuses_cached_result_until_cleared(tmp_path: Path) -> None:
+    config_path = write_pipeline_config(tmp_path / "pipeline-config.json", {"defaults": {"manifest_prefix": "v1"}})
+    base_env = {
+        "SERVERLESS_MCP_PIPELINE_CONFIG_PATH": str(config_path),
+        "OBJECT_STATE_TABLE": "object-state-table",
+        "EXECUTION_STATE_TABLE": "execution-state-table",
+    }
+    with override_env(base_env):
+        first = load_settings()
+        second = load_settings()
+        assert first is second
+
+    load_settings.cache_clear()
+    with override_env({**base_env, "MANIFEST_PREFIX": "manual"}):
+        refreshed = load_settings()
+
+    assert refreshed.manifest_prefix == "manual"

--- a/ocr-service/ocr-pipeline/tests/unit/test_runtime_ingest.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_runtime_ingest.py
@@ -25,7 +25,7 @@ class _Lookup:
 
 class _ObjectStateRepo:
     def __init__(self) -> None:
-        self.lookup = _Lookup(object_pk="tenant-a#source-bucket#docs/guide.pdf")
+        self.lookup = _Lookup(object_pk="lookup#source-bucket#docs/guide.pdf")
         self.state_by_object_pk: dict[str, ObjectStateRecord] = {}
         self.deleted: list[tuple[str, str, str | None, str | None]] = []
 
@@ -116,14 +116,14 @@ def test_handle_batch_starts_create_path_and_returns_structured_result() -> None
 
 def test_handle_batch_skips_duplicate_or_stale_events_and_execution_already_exists() -> None:
     stale_state = ObjectStateRecord(
-        pk="tenant-a#source-bucket#docs/guide.pdf",
+        pk="lookup#source-bucket#docs/guide.pdf",
         latest_version_id="v1",
         latest_sequencer="00000000000000000000000000000002",
         extract_status="EXTRACTED",
         embed_status="INDEXED",
     )
     repo = _ObjectStateRepo()
-    repo.state_by_object_pk[repo.lookup.object_pk] = stale_state
+    repo.get_state = lambda *, object_pk: stale_state  # type: ignore[assignment]
     starter = IngestWorkflowStarter(object_state_repo=repo, stepfunctions_client=_StepFunctions(), state_machine_arn="arn:aws:states:region:acct:stateMachine:extract")
 
     result = starter.handle_batch(deep_copy_event(S3_CREATE_EVENT))
@@ -236,7 +236,7 @@ def test_handle_batch_delete_path_returns_cleanup_plan_and_cleanup_executions() 
                 "profile_id": "openai-text-small",
                 "vector_bucket_name": "vector-bucket",
                 "vector_index_name": "vector-index",
-                "keys": ["openai-text-small#tenant-a#source-bucket#docs/guide.pdf#v1#chunk-1"],
+                "keys": ["openai-text-small#lookup#source-bucket#docs/guide.pdf#v1#chunk-1"],
             }
         ],
     }
@@ -257,7 +257,7 @@ def test_handle_batch_delete_path_returns_cleanup_plan_and_cleanup_executions() 
     assert delete_manager.calls == ["s3://source-bucket/docs/guide.pdf?versionId=delete-v1"]
     assert len(stepfunctions.calls) == 1
     expected_name = _build_cleanup_execution_name(
-        S3ObjectRef(tenant_id="tenant-a", bucket="source-bucket", key="docs/guide.pdf", version_id="delete-v1", sequencer="002"),
+        S3ObjectRef(tenant_id="lookup", bucket="source-bucket", key="docs/guide.pdf", version_id="delete-v1", sequencer="002"),
         cleanup_plan["cleanup_targets"][0],
     )
     assert stepfunctions.calls[0]["name"] == expected_name

--- a/ocr-service/ocr-pipeline/tests/unit/test_runtime_ingest.py
+++ b/ocr-service/ocr-pipeline/tests/unit/test_runtime_ingest.py
@@ -1,0 +1,322 @@
+"""
+EN: Ingest workflow starter tests that pin idempotency, delete cleanup, and execution contracts.
+CN: 钉住幂等、删除清理与执行契约的 ingest workflow starter 测试。
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import ANY
+
+import pytest
+from botocore.exceptions import ClientError
+
+from fixtures.events import S3_CREATE_EVENT, S3_DELETE_EVENT, deep_copy_event
+from serverless_mcp.domain.models import ChunkManifest, EmbeddingProfile, ExtractedAsset, ExtractedChunk, ObjectStateRecord, S3ObjectRef
+from serverless_mcp.runtime import ingest as runtime_ingest
+from serverless_mcp.runtime.ingest import DeleteMarkerGovernance, IngestWorkflowStarter, _build_cleanup_execution_name, _build_execution_name, _normalize_sequencer_value
+
+
+@dataclass
+class _Lookup:
+    object_pk: str
+
+
+class _ObjectStateRepo:
+    def __init__(self) -> None:
+        self.lookup = _Lookup(object_pk="tenant-a#source-bucket#docs/guide.pdf")
+        self.state_by_object_pk: dict[str, ObjectStateRecord] = {}
+        self.deleted: list[tuple[str, str, str | None, str | None]] = []
+
+    def get_lookup_for_source(self, source: S3ObjectRef):
+        return self.lookup
+
+    def get_state(self, *, object_pk: str):
+        return self.state_by_object_pk.get(object_pk)
+
+    def mark_deleted(self, *, bucket: str, key: str, version_id: str, sequencer: str | None):
+        self.deleted.append((bucket, key, version_id, sequencer))
+        return ObjectStateRecord(
+            pk=self.lookup.object_pk,
+            latest_version_id=version_id,
+            latest_sequencer=sequencer,
+            extract_status="EXTRACTED",
+            embed_status="INDEXED",
+            latest_manifest_s3_uri="s3://manifest-bucket/manifests/example.json",
+            is_deleted=True,
+        )
+
+
+class _StepFunctions:
+    def __init__(self, *, already_exists: bool = False, error_code: str | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.already_exists = already_exists
+        self.error_code = error_code
+
+    def start_execution(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if self.already_exists:
+            raise ClientError({"Error": {"Code": "ExecutionAlreadyExists", "Message": "duplicate"}}, "StartExecution")
+        if self.error_code:
+            raise ClientError({"Error": {"Code": self.error_code, "Message": "boom"}}, "StartExecution")
+        return {"executionArn": f"arn:aws:states:region:acct:execution:machine:{len(self.calls)}"}
+
+
+class _ManifestRepo:
+    def load_manifest(self, manifest_s3_uri: str):
+        assert manifest_s3_uri == "s3://manifest-bucket/manifests/example.json"
+        return ChunkManifest(
+            source=S3ObjectRef(tenant_id="tenant-a", bucket="source-bucket", key="docs/guide.pdf", version_id="v1"),
+            doc_type="pdf",
+            chunks=[ExtractedChunk(chunk_id="chunk-1", chunk_type="page_text_chunk", text="hello", doc_type="pdf", token_estimate=2)],
+            assets=[ExtractedAsset(asset_id="asset-1", chunk_type="page_image_chunk", mime_type="image/png")],
+            metadata={},
+        )
+
+
+class _DeleteLifecycleManager:
+    def __init__(self, plan: dict[str, Any] | None) -> None:
+        self.plan = plan
+        self.calls: list[str] = []
+
+    def handle_delete(self, *, source: S3ObjectRef):
+        self.calls.append(source.document_uri)
+        return self.plan
+
+
+def test_build_execution_name_and_sequencer_normalization() -> None:
+    source = S3ObjectRef(tenant_id="tenant-a", bucket="source-bucket", key="docs/guide.pdf", version_id="v1", sequencer=" 1a ")
+    another = S3ObjectRef(tenant_id="tenant-b", bucket="source-bucket", key="docs/guide.pdf", version_id="v1", sequencer="1B")
+
+    assert _normalize_sequencer_value(None) is None
+    assert _normalize_sequencer_value(" 1a ") == "0000000000000000000000000000001A"
+    assert _build_execution_name(source) != _build_execution_name(another)
+    assert len(_build_execution_name(source)) <= 80
+
+
+def test_handle_batch_starts_create_path_and_returns_structured_result() -> None:
+    repo = _ObjectStateRepo()
+    stepfunctions = _StepFunctions()
+    starter = IngestWorkflowStarter(object_state_repo=repo, stepfunctions_client=stepfunctions, state_machine_arn="arn:aws:states:region:acct:stateMachine:extract")
+
+    result = starter.handle_batch(deep_copy_event(S3_CREATE_EVENT))
+
+    assert result["started_count"] == 1
+    assert result["deleted_count"] == 0
+    assert result["skipped_count"] == 0
+    assert result["failed_count"] == 0
+    assert result["started"][0]["document_uri"].startswith("s3://source-bucket/")
+    assert result["started"][0]["execution_arn"] == "arn:aws:states:region:acct:execution:machine:1"
+    payload = json.loads(stepfunctions.calls[0]["input"])
+    assert payload["processing_state"]["extract_status"] == "QUEUED"
+    assert payload["processing_state"]["previous_version_id"] is None
+    assert payload["job"]["operation"] == "UPSERT"
+
+
+def test_handle_batch_skips_duplicate_or_stale_events_and_execution_already_exists() -> None:
+    stale_state = ObjectStateRecord(
+        pk="tenant-a#source-bucket#docs/guide.pdf",
+        latest_version_id="v1",
+        latest_sequencer="00000000000000000000000000000002",
+        extract_status="EXTRACTED",
+        embed_status="INDEXED",
+    )
+    repo = _ObjectStateRepo()
+    repo.state_by_object_pk[repo.lookup.object_pk] = stale_state
+    starter = IngestWorkflowStarter(object_state_repo=repo, stepfunctions_client=_StepFunctions(), state_machine_arn="arn:aws:states:region:acct:stateMachine:extract")
+
+    result = starter.handle_batch(deep_copy_event(S3_CREATE_EVENT))
+
+    assert result["skipped_count"] == 1
+    assert result["started_count"] == 0
+    assert result["skipped"][0]["reason"] == "duplicate_or_stale_event"
+
+    fresh_repo = _ObjectStateRepo()
+    stepfunctions = _StepFunctions(already_exists=True)
+    fresh_starter = IngestWorkflowStarter(object_state_repo=fresh_repo, stepfunctions_client=stepfunctions, state_machine_arn="arn:aws:states:region:acct:stateMachine:extract")
+
+    result = fresh_starter.handle_batch(deep_copy_event(S3_CREATE_EVENT))
+
+    assert result["skipped_count"] == 1
+    assert result["skipped"][0]["reason"] == "execution_already_exists"
+
+
+def test_build_ingest_workflow_starter_wires_runtime_context_and_optional_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = type(
+        "Settings",
+        (),
+        {
+            "step_functions_state_machine_arn": "arn:aws:states:region:acct:stateMachine:extract",
+            "execution_state_table": "execution-state",
+            "manifest_bucket": "manifest-bucket",
+            "manifest_index_table": "manifest-index",
+            "manifest_prefix": "manifests",
+        },
+    )()
+    clients = type("Clients", (), {"stepfunctions": object(), "dynamodb": object(), "s3": object()})()
+    runtime_context = type("RuntimeContext", (), {"settings": settings, "clients": clients})()
+    repositories = type(
+        "Repositories",
+        (),
+        {
+            "object_state_repo": _ObjectStateRepo(),
+            "execution_state_repo": object(),
+            "manifest_repo": object(),
+            "projection_state_repo": None,
+        },
+    )()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(runtime_ingest, "build_runtime_context", lambda settings=None: runtime_context)
+    monkeypatch.setattr(runtime_ingest, "build_runtime_repositories", lambda settings, clients: repositories)
+    monkeypatch.setattr(runtime_ingest, "resolve_step_functions_state_machine_arn", lambda state_machine_ref: state_machine_ref)
+    monkeypatch.setattr(runtime_ingest, "get_write_profiles", lambda settings: (EmbeddingProfile(
+        profile_id="openai-text-small",
+        provider="openai",
+        model="text-embedding-3-small",
+        dimension=1536,
+        vector_bucket_name="vector-bucket",
+        vector_index_name="vector-index",
+        supported_content_kinds=("text",),
+    ),))
+    monkeypatch.setattr(runtime_ingest, "DeleteMarkerGovernance", lambda **kwargs: captured.setdefault("delete_manager", kwargs) or kwargs)
+
+    starter = runtime_ingest.build_ingest_workflow_starter()
+
+    assert starter._state_machine_arn == "arn:aws:states:region:acct:stateMachine:extract"
+    assert starter._object_state_repo is repositories.object_state_repo
+    assert starter._stepfunctions is clients.stepfunctions
+    assert "delete_manager" in captured
+    assert captured["delete_manager"]["execution_state_repo"] is repositories.execution_state_repo
+    assert captured["delete_manager"]["manifest_repo"] is repositories.manifest_repo
+
+
+def test_handle_batch_records_unexpected_stepfunctions_failures_before_raising() -> None:
+    repo = _ObjectStateRepo()
+    stepfunctions = _StepFunctions(error_code="ThrottlingException")
+    starter = IngestWorkflowStarter(object_state_repo=repo, stepfunctions_client=stepfunctions, state_machine_arn="arn:aws:states:region:acct:stateMachine:extract")
+    failure_records: list[dict[str, object]] = []
+
+    original_build_failure_record = runtime_ingest._build_failure_record
+
+    def fake_build_failure_record(document_uri: str, stage: str, exc: Exception) -> dict[str, object]:
+        failure = original_build_failure_record(document_uri, stage, exc)
+        failure_records.append(failure)
+        return failure
+
+    runtime_ingest._build_failure_record = fake_build_failure_record  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(ClientError):
+            starter.handle_batch(deep_copy_event(S3_CREATE_EVENT))
+    finally:
+        runtime_ingest._build_failure_record = original_build_failure_record  # type: ignore[assignment]
+
+    assert failure_records == [
+        {
+            "document_uri": "s3://source-bucket/docs/guide.pdf?versionId=v1",
+            "stage": "stepfunctions_start",
+            "error_type": "ClientError",
+            "reason": "unexpected_error",
+            "error": ANY,
+        }
+    ]
+    assert "ThrottlingException" in str(failure_records[0]["error"])
+
+
+def test_handle_batch_delete_path_returns_cleanup_plan_and_cleanup_executions() -> None:
+    repo = _ObjectStateRepo()
+    cleanup_plan = {
+        "document_uri": "s3://source-bucket/docs/guide.pdf?versionId=delete-v1",
+        "object_pk": repo.lookup.object_pk,
+        "latest_manifest_s3_uri": "s3://manifest-bucket/manifests/example.json",
+        "cleanup_targets": [
+            {
+                "profile_id": "openai-text-small",
+                "vector_bucket_name": "vector-bucket",
+                "vector_index_name": "vector-index",
+                "keys": ["openai-text-small#tenant-a#source-bucket#docs/guide.pdf#v1#chunk-1"],
+            }
+        ],
+    }
+    delete_manager = _DeleteLifecycleManager(cleanup_plan)
+    stepfunctions = _StepFunctions()
+    starter = IngestWorkflowStarter(
+        object_state_repo=repo,
+        stepfunctions_client=stepfunctions,
+        state_machine_arn="arn:aws:states:region:acct:stateMachine:extract",
+        delete_lifecycle_manager=delete_manager,
+    )
+
+    result = starter.handle_batch(deep_copy_event(S3_DELETE_EVENT))
+
+    assert result["deleted_count"] == 1
+    assert result["deleted"][0]["cleanup_plan"] == cleanup_plan
+    assert result["deleted"][0]["cleanup_executions"][0]["profile_id"] == "openai-text-small"
+    assert delete_manager.calls == ["s3://source-bucket/docs/guide.pdf?versionId=delete-v1"]
+    assert len(stepfunctions.calls) == 1
+    expected_name = _build_cleanup_execution_name(
+        S3ObjectRef(tenant_id="tenant-a", bucket="source-bucket", key="docs/guide.pdf", version_id="delete-v1", sequencer="002"),
+        cleanup_plan["cleanup_targets"][0],
+    )
+    assert stepfunctions.calls[0]["name"] == expected_name
+    assert json.loads(stepfunctions.calls[0]["input"]) == {
+        "cleanup_plan": cleanup_plan,
+        "cleanup_target": cleanup_plan["cleanup_targets"][0],
+    }
+
+
+def test_delete_marker_governance_builds_cleanup_targets_for_each_write_enabled_profile() -> None:
+    repo = _ObjectStateRepo()
+    repo.state_by_object_pk[repo.lookup.object_pk] = ObjectStateRecord(
+        pk=repo.lookup.object_pk,
+        latest_version_id="v1",
+        latest_sequencer="00000000000000000000000000000002",
+        extract_status="EXTRACTED",
+        embed_status="INDEXED",
+        latest_manifest_s3_uri="s3://manifest-bucket/manifests/example.json",
+    )
+    governance = DeleteMarkerGovernance(
+        object_state_repo=repo,
+        manifest_repo=_ManifestRepo(),
+        profiles=(
+            EmbeddingProfile(
+                profile_id="openai-text-small",
+                provider="openai",
+                model="text-embedding-3-small",
+                dimension=1536,
+                vector_bucket_name="vector-bucket",
+                vector_index_name="vector-index",
+                supported_content_kinds=("text",),
+                enabled=True,
+                enable_write=True,
+                enable_query=True,
+            ),
+            EmbeddingProfile(
+                profile_id="query-only",
+                provider="openai",
+                model="text-embedding-3-small",
+                dimension=1536,
+                vector_bucket_name="vector-bucket",
+                vector_index_name="vector-index-2",
+                supported_content_kinds=("text",),
+                enabled=True,
+                enable_write=False,
+                enable_query=True,
+            ),
+        ),
+    )
+
+    plan = governance.handle_delete(source=S3ObjectRef(tenant_id="lookup", bucket="source-bucket", key="docs/guide.pdf", version_id="delete-v1"))
+
+    manifest = _ManifestRepo().load_manifest("s3://manifest-bucket/manifests/example.json")
+    assert plan is not None
+    assert plan["cleanup_targets"] == [
+        {
+            "profile_id": "openai-text-small",
+            "vector_bucket_name": "vector-bucket",
+            "vector_index_name": "vector-index",
+            "keys": [f"openai-text-small#{manifest.source.version_pk}#chunk-1", f"openai-text-small#{manifest.source.version_pk}#asset-1"],
+        }
+    ]

--- a/ocr-service/pytest.ini
+++ b/ocr-service/pytest.ini
@@ -2,18 +2,22 @@
 # EN: pytest configuration for serverless-kb-mcp
 # CN: serverless-kb-mcp 的 pytest 配置
 testpaths =
-    ocr-pipeline/tests
+    ocr-pipeline/tests/unit
+    ocr-pipeline/tests/contract
+    ocr-pipeline/tests/local_integration
 # EN: Keep pytest away from local reference clones and virtualenv directories.
 # CN: 让 pytest 避开本地 reference 克隆和虚拟环境目录。
 norecursedirs =
     reference
     .venv
-pythonpath = . ocr-pipeline/src
+pythonpath = . ocr-pipeline/src ocr-pipeline/tests
 markers =
     logic: Logic layer tests that do not call real AWS SDK endpoints
     contract: Contract tests for provider adapters and serialization
+    local_integration: Local integration tests using stubbed AWS boundaries
     integration: Integration tests requiring real AWS resources
     requires_network: Tests that require network access
     requires_aws: Tests that require AWS credentials
+    aws_smoke: Real AWS smoke tests that run only in nightly or manual workflows
 filterwarnings =
     ignore::pytest.PytestUnraisableExceptionWarning

--- a/ocr-service/tools/ci/validate_workflows.py
+++ b/ocr-service/tools/ci/validate_workflows.py
@@ -52,6 +52,8 @@ EXPECTED_WORKFLOWS = {
     "docs-ci.yml",
     "security-ci.yml",
     "package-release.yml",
+    "pr-validate.yml",
+    "aws-smoke.yml",
     "prod-deploy.yml",
     "destroy.yml",
     "ai-skills-sync.yml",
@@ -77,6 +79,8 @@ EXPECTED_NAMES = {
     "docs-ci.yml": "Docs CI",
     "security-ci.yml": "Security CI",
     "package-release.yml": "Package Release",
+    "pr-validate.yml": "PR Validate",
+    "aws-smoke.yml": "AWS Smoke",
     "prod-deploy.yml": "Prod Deploy",
     "destroy.yml": "Destroy",
     "ai-skills-sync.yml": "AI Skills Sync",
@@ -120,6 +124,8 @@ EXPECTED_TRIGGER_REQUIREMENTS = {
     "docs-ci.yml": {"pull_request", "workflow_dispatch"},
     "security-ci.yml": {"workflow_run", "workflow_dispatch"},
     "package-release.yml": {"workflow_run", "workflow_dispatch"},
+    "pr-validate.yml": {"pull_request", "workflow_dispatch"},
+    "aws-smoke.yml": {"schedule", "release", "workflow_dispatch"},
     "prod-deploy.yml": {"workflow_dispatch"},
     "destroy.yml": {"workflow_dispatch"},
     "ai-skills-sync.yml": {"pull_request"},
@@ -233,7 +239,7 @@ def main() -> int:
         pytest_ini = ""
     else:
         pytest_ini = pytest_ini_path.read_text(encoding="utf-8")
-    for marker in ("logic", "contract", "integration", "requires_network", "requires_aws"):
+    for marker in ("logic", "contract", "local_integration", "integration", "requires_network", "requires_aws", "aws_smoke"):
         if marker not in pytest_ini:
             errors.append(f"pytest.ini is missing marker {marker!r}")
 


### PR DESCRIPTION
Closes #126

## 变更内容
- 重建 pytest 基线与共享 fixture，补齐运行时配置、AWS client、bootstrap 的边界测试
- 补齐 ingest entrypoint、runtime.ingest、MCP gateway、lambda_wrappers、package_lambda 的 unit/contract/local integration 测试
- 增加 CDK synth / stack contract 测试
- 新增 PR 校验与 AWS smoke workflows，并同步 workflow 校验脚本与 marker 配置

## 验证面
- Python unit / contract / local integration
- Lambda packaging smoke
- CDK synth contract
- Workflow hygiene / shell safety